### PR TITLE
feat: A/B 比較モード — 2つのクエリの性能を並べて比較

### DIFF
--- a/lib/utils/comparison-delta.ts
+++ b/lib/utils/comparison-delta.ts
@@ -1,0 +1,89 @@
+/**
+ * comparison-delta.ts - Pure function to compute delta metrics between two test results
+ *
+ * Used by the comparison mode to calculate performance differences
+ * between Query A and Query B.
+ */
+
+import type { StatisticsResult } from '../types/index.js';
+
+export interface ComparisonDelta {
+  meanDiff: number;
+  meanDiffPercent: number;
+  medianDiff: number;
+  medianDiffPercent: number;
+  p50Diff: number;
+  p50DiffPercent: number;
+  p95Diff: number;
+  p95DiffPercent: number;
+  p99Diff: number;
+  p99DiffPercent: number;
+  winner: 'A' | 'B' | 'tie';
+  summary: string;
+}
+
+/**
+ * Compute the percentage difference: ((b - a) / a) * 100.
+ * Returns 0 when `a` is 0 to avoid division by zero.
+ */
+function pctDiff(a: number, b: number): number {
+  if (a === 0) return 0;
+  return ((b - a) / a) * 100;
+}
+
+/**
+ * Compute performance deltas between two StatisticsResult objects.
+ *
+ * Positive diff values mean B is slower (higher latency).
+ * Negative diff values mean B is faster (lower latency).
+ *
+ * The winner is determined by mean latency. Differences under 1% are a tie.
+ */
+export function computeComparisonDelta(
+  statsA: StatisticsResult,
+  statsB: StatisticsResult
+): ComparisonDelta {
+  const meanA = statsA.basic.mean;
+  const meanB = statsB.basic.mean;
+  const medianA = statsA.basic.median;
+  const medianB = statsB.basic.median;
+  const p50A = statsA.percentiles.p50;
+  const p50B = statsB.percentiles.p50;
+  const p95A = statsA.percentiles.p95;
+  const p95B = statsB.percentiles.p95;
+  const p99A = statsA.percentiles.p99;
+  const p99B = statsB.percentiles.p99;
+
+  const meanDiff = meanB - meanA;
+  const meanDiffPercent = pctDiff(meanA, meanB);
+
+  // Determine winner based on mean latency (lower = better)
+  let winner: 'A' | 'B' | 'tie' = 'tie';
+  if (Math.abs(meanDiffPercent) >= 1) {
+    winner = meanDiff < 0 ? 'B' : 'A';
+  }
+
+  // Build human-readable summary
+  let summary: string;
+  if (winner === 'tie') {
+    summary = `Both queries perform similarly (${Math.abs(meanDiffPercent).toFixed(1)}% difference)`;
+  } else {
+    const faster = winner;
+    summary = `Query ${faster} is ${Math.abs(meanDiffPercent).toFixed(1)}% faster (mean: ${Math.abs(meanDiff).toFixed(2)}ms)`;
+  }
+
+  return {
+    meanDiff,
+    meanDiffPercent,
+    medianDiff: medianB - medianA,
+    medianDiffPercent: pctDiff(medianA, medianB),
+    p50Diff: p50B - p50A,
+    p50DiffPercent: pctDiff(p50A, p50B),
+    p95Diff: p95B - p95A,
+    p95DiffPercent: pctDiff(p95A, p95B),
+    p99Diff: p99B - p99A,
+    p99DiffPercent: pctDiff(p99A, p99B),
+    winner,
+    summary,
+  };
+}

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -9,6 +9,7 @@ import SingleTest from './pages/SingleTest';
 import ParallelTest from './pages/ParallelTest';
 import Reports from './pages/Reports';
 import Analytics from './pages/Analytics';
+import ComparisonTest from './pages/ComparisonTest';
 import Settings from './pages/Settings';
 
 type NavItem =
@@ -22,6 +23,7 @@ const NAV: NavItem[] = [
   { section: 'Execute' },
   { path: '/single-test', icon: '▶', label: '単一テスト' },
   { path: '/parallel-test', icon: '⚡', label: '並列テスト' },
+  { path: '/comparison', icon: 'AB', label: 'A/B 比較' },
   { section: 'Insights' },
   { path: '/reports', icon: '📋', label: 'レポート' },
   { path: '/analytics', icon: '📈', label: 'アナリティクス' },
@@ -61,6 +63,7 @@ const PAGE_META: Record<string, { title: string; subtitle?: string }> = {
   '/sql-library': { title: 'SQL ライブラリ', subtitle: 'テスト用 SQL の登録・管理' },
   '/single-test': { title: '単一テスト', subtitle: 'ウォームアップ付きクエリ性能測定' },
   '/parallel-test': { title: '並列テスト', subtitle: '負荷シミュレーション & QPS 計測' },
+  '/comparison': { title: 'A/B 比較テスト', subtitle: '2つのクエリの性能を並べて比較' },
   '/reports': { title: 'レポート', subtitle: '過去のテスト結果を閲覧・エクスポート' },
   '/analytics': { title: 'アナリティクス', subtitle: 'トレンド分析と比較' },
   '/settings': { title: '設定', subtitle: 'デフォルト設定の管理' },
@@ -109,6 +112,7 @@ export default function App() {
               <Route path="/sql-library" element={<SqlLibrary />} />
               <Route path="/single-test" element={<SingleTest wsMessages={wsMessages} subscribeTestId={subscribeTestId} />} />
               <Route path="/parallel-test" element={<ParallelTest wsMessages={wsMessages} subscribeTestId={subscribeTestId} />} />
+              <Route path="/comparison" element={<ComparisonTest wsMessages={wsMessages} subscribeTestId={subscribeTestId} />} />
               <Route path="/reports" element={<Reports />} />
               <Route path="/analytics" element={<Analytics />} />
               <Route path="/settings" element={<Settings />} />

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -72,6 +72,7 @@ export const sqlApi = {
 export const testsApi = {
   runSingle: (data: unknown): Promise<{ testId: string }> => post<{ testId: string }>('/tests/single', data),
   runParallel: (data: unknown): Promise<{ testId: string }> => post<{ testId: string }>('/tests/parallel', data),
+  runComparison: (data: unknown): Promise<{ testId: string }> => post<{ testId: string }>('/tests/comparison', data),
   listResults: (): Promise<unknown[]> => get<unknown[]>('/tests/results'),
   getResult: (id: string): Promise<unknown> => get<unknown>(`/tests/results/${id}`),
 };

--- a/web-ui/src/components/ComparisonPercentilesTable.tsx
+++ b/web-ui/src/components/ComparisonPercentilesTable.tsx
@@ -1,0 +1,78 @@
+/**
+ * ComparisonPercentilesTable - Side-by-side percentile comparison with delta
+ */
+import type { Percentiles } from '../types';
+
+interface Props {
+  percentilesA: Percentiles | undefined;
+  percentilesB: Percentiles | undefined;
+  nameA: string;
+  nameB: string;
+}
+
+const ROWS: [string, keyof Percentiles][] = [
+  ['P1', 'p01'],
+  ['P5', 'p05'],
+  ['P10', 'p10'],
+  ['P25', 'p25'],
+  ['P50', 'p50'],
+  ['P75', 'p75'],
+  ['P90', 'p90'],
+  ['P95', 'p95'],
+  ['P99', 'p99'],
+  ['P99.9', 'p999'],
+];
+
+function fmt(v: number | undefined): string {
+  return v != null ? v.toFixed(2) : '-';
+}
+
+export default function ComparisonPercentilesTable({ percentilesA, percentilesB, nameA, nameB }: Props) {
+  if (!percentilesA && !percentilesB) return null;
+
+  return (
+    <div className="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th style={{ textAlign: 'right' }}>{nameA} (ms)</th>
+            <th style={{ textAlign: 'center' }}>Percentile</th>
+            <th style={{ textAlign: 'left' }}>{nameB} (ms)</th>
+            <th style={{ textAlign: 'right' }}>Delta (ms)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {ROWS.map(([label, key]) => {
+            const valA = percentilesA?.[key];
+            const valB = percentilesB?.[key];
+            const diff = (valA != null && valB != null) ? valB - valA : null;
+            const highlight = key === 'p95';
+            const diffColor = diff == null ? undefined
+              : diff < -0.01 ? 'var(--color-success)'
+              : diff > 0.01 ? 'var(--color-danger)'
+              : undefined;
+
+            return (
+              <tr key={key}>
+                <td className="font-mono" style={{
+                  textAlign: 'right',
+                  color: highlight ? 'var(--color-accent)' : undefined,
+                }}>{fmt(valA)}</td>
+                <td style={{ textAlign: 'center', fontWeight: highlight ? 600 : undefined }}>
+                  {label}
+                </td>
+                <td className="font-mono" style={{
+                  textAlign: 'left',
+                  color: highlight ? 'var(--color-accent)' : undefined,
+                }}>{fmt(valB)}</td>
+                <td className="font-mono" style={{ textAlign: 'right', color: diffColor }}>
+                  {diff != null ? `${diff >= 0 ? '+' : ''}${diff.toFixed(2)}` : '-'}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web-ui/src/components/DeltaSummaryBar.tsx
+++ b/web-ui/src/components/DeltaSummaryBar.tsx
@@ -1,0 +1,54 @@
+/**
+ * DeltaSummaryBar - Shows comparison winner and key delta metrics
+ */
+import type { ComparisonDelta } from '../types';
+
+interface Props {
+  delta: ComparisonDelta;
+  nameA: string;
+  nameB: string;
+}
+
+function DeltaChip({ label, diff, pct }: { label: string; diff: number; pct: number }) {
+  const isBetter = diff < 0;  // negative = B is faster (lower latency)
+  const color = Math.abs(pct) < 1 ? 'var(--color-text-muted)' : isBetter ? 'var(--color-success)' : 'var(--color-danger)';
+  const sign = diff >= 0 ? '+' : '';
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <div className="text-xs text-muted">{label}</div>
+      <div className="font-mono" style={{ color, fontSize: 'var(--text-sm)' }}>
+        {sign}{diff.toFixed(2)}ms ({sign}{pct.toFixed(1)}%)
+      </div>
+    </div>
+  );
+}
+
+export default function DeltaSummaryBar({ delta, nameA, nameB }: Props) {
+  const winnerLabel = delta.winner === 'tie'
+    ? 'TIE'
+    : delta.winner === 'A' ? nameA : nameB;
+  const winnerColor = delta.winner === 'tie'
+    ? 'var(--color-text-muted)'
+    : 'var(--color-success)';
+
+  return (
+    <div className="card mb-4 fade-in" style={{
+      borderLeft: `4px solid ${winnerColor}`,
+      display: 'grid',
+      gridTemplateColumns: '1fr repeat(3, auto)',
+      gap: 'var(--space-4)',
+      alignItems: 'center',
+    }}>
+      <div>
+        <div className="text-xs text-muted">Winner</div>
+        <div style={{ fontSize: 'var(--text-lg)', fontWeight: 600, color: winnerColor }}>
+          {winnerLabel}
+        </div>
+        <div className="text-xs text-muted">{delta.summary}</div>
+      </div>
+      <DeltaChip label="Mean" diff={delta.meanDiff} pct={delta.meanDiffPercent} />
+      <DeltaChip label="P95" diff={delta.p95Diff} pct={delta.p95DiffPercent} />
+      <DeltaChip label="P99" diff={delta.p99Diff} pct={delta.p99DiffPercent} />
+    </div>
+  );
+}

--- a/web-ui/src/components/ExplainPanel.tsx
+++ b/web-ui/src/components/ExplainPanel.tsx
@@ -1,0 +1,26 @@
+/**
+ * EXPLAIN result display component
+ * Extracted from SingleTest.tsx for reuse in ComparisonTest
+ */
+import type { ExplainAnalyze } from '../types';
+
+interface Props {
+  explain: ExplainAnalyze | undefined;
+}
+
+export default function ExplainPanel({ explain }: Props) {
+  if (!explain) return <div className="empty-state"><p>EXPLAIN データなし（無効またはエラー）</p></div>;
+  return (
+    <div>
+      {explain.data != null && (
+        <div className="code-block">{JSON.stringify(explain.data, null, 2)}</div>
+      )}
+      {explain.analyze?.tree && (
+        <>
+          <div className="section-title mt-4">EXPLAIN ANALYZE</div>
+          <div className="code-block">{explain.analyze.tree}</div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/web-ui/src/components/HistogramChart.tsx
+++ b/web-ui/src/components/HistogramChart.tsx
@@ -1,0 +1,29 @@
+/**
+ * Latency distribution histogram component
+ * Extracted from SingleTest.tsx for reuse in ComparisonTest
+ */
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid,
+  Tooltip, ResponsiveContainer
+} from 'recharts';
+import type { Distribution } from '../types';
+
+interface Props {
+  distribution: Distribution | undefined;
+}
+
+export default function HistogramChart({ distribution }: Props) {
+  if (!distribution?.buckets) return <div className="empty-state"><p>分布データなし</p></div>;
+  const data = distribution.buckets.map(b => ({ name: `${b.min?.toFixed(0)}ms`, count: b.count }));
+  return (
+    <ResponsiveContainer width="100%" height={220}>
+      <BarChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+        <XAxis dataKey="name" tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }} />
+        <YAxis tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }} />
+        <Tooltip contentStyle={{ background: 'var(--color-surface-2)', border: '1px solid var(--color-border)', borderRadius: 6 }} />
+        <Bar dataKey="count" fill="var(--color-accent)" radius={[3, 3, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/web-ui/src/components/OverlaidHistogram.tsx
+++ b/web-ui/src/components/OverlaidHistogram.tsx
@@ -1,0 +1,64 @@
+/**
+ * OverlaidHistogram - Two distributions overlaid on a single bar chart
+ */
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid,
+  Tooltip, ResponsiveContainer, Legend,
+} from 'recharts';
+import type { Distribution } from '../types';
+
+interface Props {
+  distributionA: Distribution | undefined;
+  distributionB: Distribution | undefined;
+  nameA: string;
+  nameB: string;
+}
+
+export default function OverlaidHistogram({ distributionA, distributionB, nameA, nameB }: Props) {
+  const bucketsA = distributionA?.buckets;
+  const bucketsB = distributionB?.buckets;
+
+  if (!bucketsA && !bucketsB) {
+    return <div className="empty-state"><p>分布データなし</p></div>;
+  }
+
+  // Build a unified set of bucket labels from both distributions
+  const labelMap = new Map<string, { countA: number; countB: number }>();
+
+  bucketsA?.forEach(b => {
+    const label = `${b.min?.toFixed(0)}`;
+    const entry = labelMap.get(label) || { countA: 0, countB: 0 };
+    entry.countA = b.count;
+    labelMap.set(label, entry);
+  });
+
+  bucketsB?.forEach(b => {
+    const label = `${b.min?.toFixed(0)}`;
+    const entry = labelMap.get(label) || { countA: 0, countB: 0 };
+    entry.countB = b.count;
+    labelMap.set(label, entry);
+  });
+
+  // Sort by numeric value of label
+  const data = Array.from(labelMap.entries())
+    .sort((a, b) => Number(a[0]) - Number(b[0]))
+    .map(([label, counts]) => ({
+      name: `${label}ms`,
+      [nameA]: counts.countA,
+      [nameB]: counts.countB,
+    }));
+
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <BarChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+        <XAxis dataKey="name" tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }} />
+        <YAxis tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }} />
+        <Tooltip contentStyle={{ background: 'var(--color-surface-2)', border: '1px solid var(--color-border)', borderRadius: 6 }} />
+        <Legend />
+        <Bar dataKey={nameA} fill="var(--color-accent)" fillOpacity={0.6} radius={[3, 3, 0, 0]} />
+        <Bar dataKey={nameB} fill="var(--color-warning)" fillOpacity={0.6} radius={[3, 3, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/web-ui/src/components/RecommendPanel.tsx
+++ b/web-ui/src/components/RecommendPanel.tsx
@@ -1,0 +1,38 @@
+/**
+ * Recommendations display component
+ * Extracted from SingleTest.tsx for reuse in ComparisonTest
+ */
+import type { QueryPlan } from '../types';
+
+interface Props {
+  plan: QueryPlan | undefined;
+}
+
+export default function RecommendPanel({ plan }: Props) {
+  if (!plan) return <div className="empty-state"><p>推奨データなし</p></div>;
+  const issues = plan.issues || [];
+  const recs = plan.recommendations || [];
+  return (
+    <div>
+      {issues.length > 0 && (
+        <>
+          <div className="section-title">検出された問題</div>
+          {issues.map((iss, i) => (
+            <div key={i} className="alert alert-error" style={{ marginBottom: 8 }}>{iss}</div>
+          ))}
+        </>
+      )}
+      {recs.length > 0 && (
+        <>
+          <div className="section-title mt-4">推奨事項</div>
+          {recs.map((rec, i) => (
+            <div key={i} className="alert alert-info" style={{ marginBottom: 8 }}>{rec}</div>
+          ))}
+        </>
+      )}
+      {issues.length === 0 && recs.length === 0 && (
+        <div className="empty-state"><p>特に問題は検出されませんでした</p></div>
+      )}
+    </div>
+  );
+}

--- a/web-ui/src/hooks/useTestExecution.ts
+++ b/web-ui/src/hooks/useTestExecution.ts
@@ -6,7 +6,7 @@
  * SingleTest and ParallelTest pages.
  */
 import { useReducer, useEffect, useState } from 'react';
-import type { RunState, RunAction, WsMessage } from '../types';
+import type { RunState, RunAction, WsMessage, ComparisonResult } from '../types';
 
 const INIT_RUN: RunState = {
   runState: null,
@@ -14,6 +14,7 @@ const INIT_RUN: RunState = {
   liveData: [],
   result: null,
   results: null,
+  comparison: null,
   errorMsg: '',
 };
 
@@ -33,6 +34,7 @@ function runReducer(state: RunState, action: RunAction): RunState {
         runState: 'complete',
         result: action.data.result || null,
         results: action.data.results || null,
+        comparison: action.data.comparison || null,
       };
     case 'error':
       return { ...state, runState: 'error', errorMsg: action.data.message };
@@ -55,7 +57,21 @@ export default function useTestExecution(wsMessages: WsMessage[]): {
     const relevant = wsMessages.filter(m => m.testId === currentTestId);
     if (!relevant.length) return;
     const last = relevant[relevant.length - 1];
-    if (['progress', 'complete', 'error'].includes(last.type)) dispatch(last as RunAction);
+    if (last.type === 'complete' && last.data && 'resultA' in (last.data as unknown as Record<string, unknown>)) {
+      // Comparison test complete — transform to RunAction with comparison field
+      const d = last.data as unknown as Record<string, unknown>;
+      const comparison: ComparisonResult = {
+        resultA: { statistics: (d.resultA as Record<string, unknown>)?.statistics, explainAnalyze: (d.resultA as Record<string, unknown>)?.explainAnalyze } as ComparisonResult['resultA'],
+        resultB: { statistics: (d.resultB as Record<string, unknown>)?.statistics, explainAnalyze: (d.resultB as Record<string, unknown>)?.explainAnalyze } as ComparisonResult['resultB'],
+        delta: d.delta as ComparisonResult['delta'],
+        executionMode: d.executionMode as ComparisonResult['executionMode'],
+        testNameA: (d.testNameA as string) || 'Query A',
+        testNameB: (d.testNameB as string) || 'Query B',
+      };
+      dispatch({ type: 'complete', data: { comparison } });
+    } else if (['progress', 'complete', 'error'].includes(last.type)) {
+      dispatch(last as RunAction);
+    }
   }, [wsMessages, currentTestId]);
 
   return { run, dispatch, currentTestId, setCurrentTestId };

--- a/web-ui/src/pages/ComparisonTest.tsx
+++ b/web-ui/src/pages/ComparisonTest.tsx
@@ -1,0 +1,421 @@
+/**
+ * ComparisonTest - A/B comparison test page
+ *
+ * Runs two queries with identical parameters and displays
+ * side-by-side results with delta metrics.
+ */
+import { useState, useEffect } from 'react';
+import { connectionsApi, sqlApi, testsApi } from '../api/client';
+import StatCardsGrid from '../components/StatCardsGrid';
+import ProgressBar from '../components/ProgressBar';
+import PercentilesTable from '../components/PercentilesTable';
+import HistogramChart from '../components/HistogramChart';
+import ExplainPanel from '../components/ExplainPanel';
+import RecommendPanel from '../components/RecommendPanel';
+import DeltaSummaryBar from '../components/DeltaSummaryBar';
+import OverlaidHistogram from '../components/OverlaidHistogram';
+import ComparisonPercentilesTable from '../components/ComparisonPercentilesTable';
+import useTestExecution from '../hooks/useTestExecution';
+import type {
+  Connection, SqlItem, ComparisonTestForm,
+  ComparisonResult, WsMessage, RunAction,
+} from '../types';
+
+interface Props {
+  wsMessages: WsMessage[];
+  subscribeTestId: (testId: string) => void;
+}
+
+export default function ComparisonTest({ wsMessages, subscribeTestId }: Props) {
+  const [connections, setConnections] = useState<Connection[]>([]);
+  const [sqlItems, setSqlItems] = useState<SqlItem[]>([]);
+
+  const [form, setForm] = useState<ComparisonTestForm>({
+    connectionId: '',
+    executionMode: 'sequential',
+    sqlModeA: 'direct',
+    sqlIdA: '',
+    sqlTextA: '',
+    testNameA: 'Query A',
+    sqlModeB: 'direct',
+    sqlIdB: '',
+    sqlTextB: '',
+    testNameB: 'Query B',
+    testIterations: 20,
+    enableWarmup: true,
+    warmupPercentage: 20,
+    removeOutliers: false,
+    outlierMethod: 'iqr',
+    enableExplainAnalyze: true,
+    enableOptimizerTrace: false,
+    enableBufferPoolMonitoring: true,
+    enablePerformanceSchema: false,
+  });
+  const setF = (k: string, v: string | number | boolean) => setForm(f => ({ ...f, [k]: v }));
+
+  const { run, dispatch, setCurrentTestId } = useTestExecution(wsMessages);
+  const [activeTab, setActiveTab] = useState('stats');
+
+  useEffect(() => {
+    connectionsApi.list().then(setConnections).catch(() => { });
+    sqlApi.list().then(setSqlItems).catch(() => { });
+  }, []);
+
+  // Parse comparison data from WebSocket complete message
+  useEffect(() => {
+    if (run.runState !== 'complete') return;
+    // The hook sets run.comparison when complete data includes comparison fields
+  }, [run.runState]);
+
+  // Build comparison result from the raw complete event
+  const comparison: ComparisonResult | null = run.comparison;
+
+  const handleRun = async () => {
+    const sqlTextA = form.sqlModeA === 'library'
+      ? (sqlItems.find(s => s.id === form.sqlIdA)?.sql || '')
+      : form.sqlTextA;
+    const sqlTextB = form.sqlModeB === 'library'
+      ? (sqlItems.find(s => s.id === form.sqlIdB)?.sql || '')
+      : form.sqlTextB;
+
+    if (!form.connectionId) return dispatch({ type: 'error', data: { message: '接続先を選択してください' } } as RunAction);
+    if (!sqlTextA.trim()) return dispatch({ type: 'error', data: { message: 'Query A の SQL を入力してください' } } as RunAction);
+    if (!sqlTextB.trim()) return dispatch({ type: 'error', data: { message: 'Query B の SQL を入力してください' } } as RunAction);
+
+    dispatch({ type: 'start', progress: { phase: 'starting', current: 0, total: form.testIterations, duration: null } });
+    setCurrentTestId(null);
+
+    try {
+      const { testId } = await testsApi.runComparison({
+        connectionId: form.connectionId,
+        sqlTextA,
+        sqlTextB,
+        testNameA: form.testNameA,
+        testNameB: form.testNameB,
+        executionMode: form.executionMode,
+        testIterations: form.testIterations,
+        enableWarmup: form.enableWarmup,
+        warmupPercentage: form.warmupPercentage,
+        removeOutliers: form.removeOutliers,
+        outlierMethod: form.outlierMethod,
+        enableExplainAnalyze: form.enableExplainAnalyze,
+        enableOptimizerTrace: form.enableOptimizerTrace,
+        enableBufferPoolMonitoring: form.enableBufferPoolMonitoring,
+        enablePerformanceSchema: form.enablePerformanceSchema,
+      });
+      setCurrentTestId(testId);
+      subscribeTestId?.(testId);
+    } catch (e) {
+      dispatch({ type: 'error', data: { message: (e as Error).message } });
+    }
+  };
+
+  // Progress label based on phase prefix
+  const progressLabel = (() => {
+    const phase = run.progress.phase || '';
+    if (phase.startsWith('queryA:')) {
+      const sub = phase.replace('queryA:', '');
+      return sub === 'warmup' ? 'Query A: Warmup...' : 'Query A: Measuring...';
+    }
+    if (phase.startsWith('queryB:')) {
+      const sub = phase.replace('queryB:', '');
+      return sub === 'warmup' ? 'Query B: Warmup...' : 'Query B: Measuring...';
+    }
+    return 'Starting...';
+  })();
+
+  const statsA = comparison?.resultA?.statistics;
+  const statsB = comparison?.resultB?.statistics;
+
+  /** SQL input section for a single query */
+  const renderSqlInput = (side: 'A' | 'B') => {
+    const modeKey = side === 'A' ? 'sqlModeA' : 'sqlModeB';
+    const idKey = side === 'A' ? 'sqlIdA' : 'sqlIdB';
+    const textKey = side === 'A' ? 'sqlTextA' : 'sqlTextB';
+    const nameKey = side === 'A' ? 'testNameA' : 'testNameB';
+    const mode = form[modeKey] as string;
+
+    return (
+      <div style={{ border: '1px solid var(--color-border)', borderRadius: 8, padding: 'var(--space-3)', marginBottom: 'var(--space-3)' }}>
+        <div className="flex items-center gap-2 mb-4" style={{ marginBottom: 'var(--space-2)' }}>
+          <span style={{ fontWeight: 600 }}>Query {side}</span>
+          <div className="flex gap-2" style={{ marginLeft: 'auto' }}>
+            {(['library', 'direct'] as const).map(m => (
+              <button key={m} className={`btn btn-sm ${mode === m ? 'btn-accent' : 'btn-secondary'}`}
+                style={{ fontSize: 'var(--text-xs)', padding: '2px 8px' }}
+                onClick={() => setF(modeKey, m)}>
+                {m === 'library' ? 'Lib' : 'SQL'}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="form-group" style={{ marginBottom: 'var(--space-2)' }}>
+          <input className="form-input" placeholder={`Query ${side} name`}
+            value={form[nameKey] as string} onChange={e => setF(nameKey, e.target.value)} />
+        </div>
+
+        {mode === 'library' ? (
+          <div className="form-group" style={{ marginBottom: 0 }}>
+            <select className="form-select" value={form[idKey] as string} onChange={e => setF(idKey, e.target.value)}>
+              <option value="">SQL を選択...</option>
+              {sqlItems.map(s => <option key={s.id} value={s.id}>[{s.category}] {s.name}</option>)}
+            </select>
+          </div>
+        ) : (
+          <div className="form-group" style={{ marginBottom: 0 }}>
+            <textarea className="form-textarea" rows={3}
+              placeholder={`SELECT * FROM ...`}
+              value={form[textKey] as string} onChange={e => setF(textKey, e.target.value)} />
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '380px 1fr', gap: 'var(--space-5)', alignItems: 'start' }}>
+
+      {/* Settings panel */}
+      <div className="card">
+        <div className="card-title mb-4">A/B Comparison Settings</div>
+
+        <div className="form-group">
+          <label className="form-label">接続先 *</label>
+          <select className="form-select" value={form.connectionId} onChange={e => setF('connectionId', e.target.value)}>
+            <option value="">接続を選択...</option>
+            {connections.map(c => <option key={c.id} value={c.id}>{c.name || `${c.host}/${c.database}`}</option>)}
+          </select>
+        </div>
+
+        <div className="form-group">
+          <label className="form-label">実行方式</label>
+          <div className="flex gap-2">
+            {([['sequential', 'Sequential'], ['parallel', 'Parallel']] as const).map(([val, label]) => (
+              <button key={val}
+                className={`btn btn-sm ${form.executionMode === val ? 'btn-accent' : 'btn-secondary'}`}
+                onClick={() => setF('executionMode', val)}>
+                {label}
+              </button>
+            ))}
+          </div>
+          <div className="text-xs text-muted" style={{ marginTop: 4 }}>
+            {form.executionMode === 'sequential'
+              ? 'A → B を順に実行（公平だがキャッシュ影響あり）'
+              : 'A, B を同時実行（実環境に近いがリソース競合あり）'}
+          </div>
+        </div>
+
+        {renderSqlInput('A')}
+        {renderSqlInput('B')}
+
+        <div className="form-group">
+          <label className="form-label">実行回数</label>
+          <input className="form-input" type="number" min="1" max="1000"
+            value={form.testIterations} onChange={e => setF('testIterations', Number(e.target.value))} />
+        </div>
+
+        <div style={{ borderTop: '1px solid var(--color-border)', paddingTop: 'var(--space-3)', marginBottom: 'var(--space-3)' }}>
+          {([
+            ['enableWarmup', 'Warmup'],
+            ['removeOutliers', 'Remove Outliers'],
+            ['enableExplainAnalyze', 'EXPLAIN ANALYZE'],
+            ['enableOptimizerTrace', 'Optimizer Trace'],
+            ['enableBufferPoolMonitoring', 'Buffer Pool'],
+            ['enablePerformanceSchema', 'Performance Schema'],
+          ] as const).map(([key, label]) => (
+            <div key={key} className="toggle-row">
+              <span className="toggle-label">{label}</span>
+              <label className="toggle">
+                <input type="checkbox" checked={form[key] as boolean} onChange={e => setF(key, e.target.checked)} />
+                <span className="toggle-slider" />
+              </label>
+            </div>
+          ))}
+        </div>
+
+        {form.removeOutliers && (
+          <div className="form-group">
+            <label className="form-label">Outlier Method</label>
+            <select className="form-select" value={form.outlierMethod} onChange={e => setF('outlierMethod', e.target.value)}>
+              <option value="iqr">IQR</option>
+              <option value="zscore">Z-Score</option>
+              <option value="mad">MAD</option>
+            </select>
+          </div>
+        )}
+
+        <button className="btn btn-primary btn-lg" style={{ width: '100%' }}
+          onClick={handleRun} disabled={run.runState === 'running'}>
+          {run.runState === 'running' ? <><span className="spinner" /> Running...</> : 'Run A/B Comparison'}
+        </button>
+
+        {run.errorMsg && <div className="alert alert-error mt-4">{run.errorMsg}</div>}
+      </div>
+
+      {/* Results panel */}
+      <div>
+        {/* Progress */}
+        {run.runState === 'running' && (
+          <ProgressBar
+            current={run.progress.current}
+            total={run.progress.total}
+            label={progressLabel}
+          >
+            {run.progress.duration != null && (
+              <div className="text-muted text-sm" style={{ marginTop: 4 }}>
+                Latest: {run.progress.duration?.toFixed(2)} ms
+              </div>
+            )}
+          </ProgressBar>
+        )}
+
+        {/* Delta summary */}
+        {comparison?.delta && (
+          <DeltaSummaryBar
+            delta={comparison.delta}
+            nameA={comparison.testNameA || 'Query A'}
+            nameB={comparison.testNameB || 'Query B'}
+          />
+        )}
+
+        {/* Side-by-side stat cards */}
+        {comparison && (statsA || statsB) && (
+          <div className="card-grid card-grid-2 mb-4 fade-in">
+            <div>
+              <div className="section-title" style={{ marginBottom: 'var(--space-2)' }}>{comparison.testNameA || 'Query A'}</div>
+              {statsA && <StatCardsGrid items={[
+                { label: 'Mean', value: statsA.basic?.mean?.toFixed(2), unit: 'ms' },
+                { label: 'P95', value: statsA.percentiles?.p95?.toFixed(2), unit: 'ms', highlight: true },
+                { label: 'P99', value: statsA.percentiles?.p99?.toFixed(2), unit: 'ms' },
+                { label: 'CV', value: statsA.spread?.cv?.toFixed(2), unit: '%' },
+              ]} />}
+            </div>
+            <div>
+              <div className="section-title" style={{ marginBottom: 'var(--space-2)' }}>{comparison.testNameB || 'Query B'}</div>
+              {statsB && <StatCardsGrid items={[
+                { label: 'Mean', value: statsB.basic?.mean?.toFixed(2), unit: 'ms' },
+                { label: 'P95', value: statsB.percentiles?.p95?.toFixed(2), unit: 'ms', highlight: true },
+                { label: 'P99', value: statsB.percentiles?.p99?.toFixed(2), unit: 'ms' },
+                { label: 'CV', value: statsB.spread?.cv?.toFixed(2), unit: '%' },
+              ]} />}
+            </div>
+          </div>
+        )}
+
+        {/* Detail tabs */}
+        {comparison && (
+          <div className="card fade-in">
+            <div className="tabs">
+              {([
+                ['stats', 'Stats'],
+                ['histogram', 'Distribution'],
+                ['explain', 'EXPLAIN'],
+                ['recommend', 'Recommend'],
+              ] as const).map(([id, label]) => (
+                <button key={id} className={`tab-btn${activeTab === id ? ' active' : ''}`}
+                  onClick={() => setActiveTab(id)}>{label}</button>
+              ))}
+            </div>
+
+            {activeTab === 'stats' && (
+              <div>
+                {/* Side-by-side basic stats */}
+                <div className="card-grid card-grid-2 mb-4">
+                  <div>
+                    <div className="section-title">{comparison.testNameA} - Basic Stats</div>
+                    <div className="table-wrap">
+                      <table>
+                        <tbody>
+                          {([
+                            ['Min', statsA?.basic?.min],
+                            ['Max', statsA?.basic?.max],
+                            ['Mean', statsA?.basic?.mean],
+                            ['Median', statsA?.basic?.median],
+                            ['StdDev', statsA?.spread?.stdDev],
+                            ['IQR', statsA?.spread?.iqr],
+                          ] as [string, number | undefined][]).map(([l, v]) => (
+                            <tr key={l}><td className="text-muted">{l}</td><td className="font-mono">{v != null ? `${v.toFixed(2)} ms` : '-'}</td></tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                  <div>
+                    <div className="section-title">{comparison.testNameB} - Basic Stats</div>
+                    <div className="table-wrap">
+                      <table>
+                        <tbody>
+                          {([
+                            ['Min', statsB?.basic?.min],
+                            ['Max', statsB?.basic?.max],
+                            ['Mean', statsB?.basic?.mean],
+                            ['Median', statsB?.basic?.median],
+                            ['StdDev', statsB?.spread?.stdDev],
+                            ['IQR', statsB?.spread?.iqr],
+                          ] as [string, number | undefined][]).map(([l, v]) => (
+                            <tr key={l}><td className="text-muted">{l}</td><td className="font-mono">{v != null ? `${v.toFixed(2)} ms` : '-'}</td></tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="section-title">Percentile Comparison</div>
+                <ComparisonPercentilesTable
+                  percentilesA={statsA?.percentiles}
+                  percentilesB={statsB?.percentiles}
+                  nameA={comparison.testNameA || 'Query A'}
+                  nameB={comparison.testNameB || 'Query B'}
+                />
+              </div>
+            )}
+
+            {activeTab === 'histogram' && (
+              <OverlaidHistogram
+                distributionA={statsA?.distribution}
+                distributionB={statsB?.distribution}
+                nameA={comparison.testNameA || 'Query A'}
+                nameB={comparison.testNameB || 'Query B'}
+              />
+            )}
+
+            {activeTab === 'explain' && (
+              <div className="card-grid card-grid-2">
+                <div>
+                  <div className="section-title">{comparison.testNameA}</div>
+                  <ExplainPanel explain={comparison.resultA?.explainAnalyze} />
+                </div>
+                <div>
+                  <div className="section-title">{comparison.testNameB}</div>
+                  <ExplainPanel explain={comparison.resultB?.explainAnalyze} />
+                </div>
+              </div>
+            )}
+
+            {activeTab === 'recommend' && (
+              <div className="card-grid card-grid-2">
+                <div>
+                  <div className="section-title">{comparison.testNameA}</div>
+                  <RecommendPanel plan={comparison.resultA?.explainAnalyze?.queryPlan} />
+                </div>
+                <div>
+                  <div className="section-title">{comparison.testNameB}</div>
+                  <RecommendPanel plan={comparison.resultB?.explainAnalyze?.queryPlan} />
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {!comparison && !run.runState && (
+          <div className="empty-state">
+            <div className="empty-icon">A/B</div>
+            <p>左のパネルで2つのクエリを設定して比較テストを実行してください</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web-ui/src/pages/Reports.tsx
+++ b/web-ui/src/pages/Reports.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react';
 import { reportsApi } from '../api/client';
+import DeltaSummaryBar from '../components/DeltaSummaryBar';
+import ComparisonPercentilesTable from '../components/ComparisonPercentilesTable';
 import type {
   ReportSummary, ReportDetail, SingleTestResult,
-  ParallelResults, FileStats,
+  ParallelResults, FileStats, ComparisonDelta, Statistics,
 } from '../types';
 
 export default function Reports() {
@@ -39,6 +41,7 @@ export default function Reports() {
   };
 
   const typeBadge = (type: string) => {
+    if (type === 'comparison') return <span className="badge badge-yellow">A/B</span>;
     if (type === 'parallel') return <span className="badge badge-blue">並列</span>;
     if (type === 'batch') return <span className="badge badge-yellow">バッチ</span>;
     return <span className="badge badge-green">単一</span>;
@@ -91,7 +94,89 @@ export default function Reports() {
 
         {detailLoading && <div className="empty-state"><div className="spinner spinner-lg" /></div>}
 
-        {detail && !detailLoading && (() => {
+        {/* Comparison result detail */}
+        {detail && !detailLoading && (detail as unknown as Record<string, unknown>).type === 'comparison' && (() => {
+          const d = detail as unknown as Record<string, unknown>;
+          const resultA = d.resultA as SingleTestResult | undefined;
+          const resultB = d.resultB as SingleTestResult | undefined;
+          const delta = d.delta as ComparisonDelta | null;
+          const testNameA = (d.testNameA as string) || 'Query A';
+          const testNameB = (d.testNameB as string) || 'Query B';
+          const executionMode = (d.executionMode as string) || 'sequential';
+          const statsA = resultA?.statistics;
+          const statsB = resultB?.statistics;
+
+          return (
+            <div className="fade-in">
+              <div className="card-header mb-4">
+                <div>
+                  <div className="card-title">{selected!.testName || selected!.id}</div>
+                  <div className="text-xs text-muted">
+                    {selected!.id} | {executionMode === 'sequential' ? 'Sequential' : 'Parallel'}
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  {(['json', 'csv', 'html', 'markdown'] as const).map(fmt => (
+                    <button key={fmt} className="btn btn-secondary btn-sm" onClick={() => handleExport(fmt)}>
+                      {fmt.toUpperCase()}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {delta && <DeltaSummaryBar delta={delta} nameA={testNameA} nameB={testNameB} />}
+
+              {/* Side-by-side stat cards */}
+              <div className="card-grid card-grid-2 mb-4">
+                <div>
+                  <div className="section-title">{testNameA}</div>
+                  <div className="card-grid card-grid-4">
+                    {[
+                      { label: 'Mean', value: statsA?.basic?.mean, unit: 'ms' },
+                      { label: 'P95', value: statsA?.percentiles?.p95, unit: 'ms' },
+                      { label: 'P99', value: statsA?.percentiles?.p99, unit: 'ms' },
+                      { label: 'CV', value: statsA?.spread?.cv, unit: '%' },
+                    ].map(s => (
+                      <div key={s.label} className="stat-card">
+                        <div className="stat-label">{s.label}</div>
+                        <div className="stat-value">{s.value ?? '-'}<span className="stat-unit">{s.unit}</span></div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                <div>
+                  <div className="section-title">{testNameB}</div>
+                  <div className="card-grid card-grid-4">
+                    {[
+                      { label: 'Mean', value: statsB?.basic?.mean, unit: 'ms' },
+                      { label: 'P95', value: statsB?.percentiles?.p95, unit: 'ms' },
+                      { label: 'P99', value: statsB?.percentiles?.p99, unit: 'ms' },
+                      { label: 'CV', value: statsB?.spread?.cv, unit: '%' },
+                    ].map(s => (
+                      <div key={s.label} className="stat-card">
+                        <div className="stat-label">{s.label}</div>
+                        <div className="stat-value">{s.value ?? '-'}<span className="stat-unit">{s.unit}</span></div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              <div className="card">
+                <div className="section-title">Percentile Comparison</div>
+                <ComparisonPercentilesTable
+                  percentilesA={statsA?.percentiles}
+                  percentilesB={statsB?.percentiles}
+                  nameA={testNameA}
+                  nameB={testNameB}
+                />
+              </div>
+            </div>
+          );
+        })()}
+
+        {/* Standard result detail */}
+        {detail && !detailLoading && (detail as unknown as Record<string, unknown>).type !== 'comparison' && (() => {
           const result: SingleTestResult | undefined = detail.result || (Array.isArray(detail.results) ? detail.results[0] as SingleTestResult : undefined);
           const stats = result?.statistics;
           return (

--- a/web-ui/src/pages/SingleTest.tsx
+++ b/web-ui/src/pages/SingleTest.tsx
@@ -1,83 +1,16 @@
 import { useState, useEffect } from 'react';
 import { connectionsApi, sqlApi, testsApi } from '../api/client';
-import {
-  BarChart, Bar, XAxis, YAxis, CartesianGrid,
-  Tooltip, ResponsiveContainer
-} from 'recharts';
 import StatCardsGrid from '../components/StatCardsGrid';
 import ProgressBar from '../components/ProgressBar';
 import PercentilesTable from '../components/PercentilesTable';
+import HistogramChart from '../components/HistogramChart';
+import ExplainPanel from '../components/ExplainPanel';
+import RecommendPanel from '../components/RecommendPanel';
 import useTestExecution from '../hooks/useTestExecution';
 import type {
   Connection, SqlItem, SingleTestForm,
-  Distribution, ExplainAnalyze, QueryPlan,
   WsMessage, RunAction,
 } from '../types';
-
-/** Latency distribution histogram */
-function HistogramChart({ distribution }: { distribution: Distribution | undefined }) {
-  if (!distribution?.buckets) return <div className="empty-state"><p>分布データなし</p></div>;
-  const data = distribution.buckets.map(b => ({ name: `${b.min?.toFixed(0)}ms`, count: b.count }));
-  return (
-    <ResponsiveContainer width="100%" height={220}>
-      <BarChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
-        <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
-        <XAxis dataKey="name" tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }} />
-        <YAxis tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }} />
-        <Tooltip contentStyle={{ background: 'var(--color-surface-2)', border: '1px solid var(--color-border)', borderRadius: 6 }} />
-        <Bar dataKey="count" fill="var(--color-accent)" radius={[3, 3, 0, 0]} />
-      </BarChart>
-    </ResponsiveContainer>
-  );
-}
-
-/** EXPLAIN result display */
-function ExplainPanel({ explain }: { explain: ExplainAnalyze | undefined }) {
-  if (!explain) return <div className="empty-state"><p>EXPLAIN データなし（無効またはエラー）</p></div>;
-  return (
-    <div>
-      {explain.data != null && (
-        <div className="code-block">{JSON.stringify(explain.data, null, 2)}</div>
-      )}
-      {explain.analyze?.tree && (
-        <>
-          <div className="section-title mt-4">EXPLAIN ANALYZE</div>
-          <div className="code-block">{explain.analyze.tree}</div>
-        </>
-      )}
-    </div>
-  );
-}
-
-/** Recommendations */
-function RecommendPanel({ plan }: { plan: QueryPlan | undefined }) {
-  if (!plan) return <div className="empty-state"><p>推奨データなし</p></div>;
-  const issues = plan.issues || [];
-  const recs = plan.recommendations || [];
-  return (
-    <div>
-      {issues.length > 0 && (
-        <>
-          <div className="section-title">⚠ 検出された問題</div>
-          {issues.map((iss, i) => (
-            <div key={i} className="alert alert-error" style={{ marginBottom: 8 }}>🔴 {iss}</div>
-          ))}
-        </>
-      )}
-      {recs.length > 0 && (
-        <>
-          <div className="section-title mt-4">💡 推奨事項</div>
-          {recs.map((rec, i) => (
-            <div key={i} className="alert alert-info" style={{ marginBottom: 8 }}>➤ {rec}</div>
-          ))}
-        </>
-      )}
-      {issues.length === 0 && recs.length === 0 && (
-        <div className="empty-state"><p>特に問題は検出されませんでした</p></div>
-      )}
-    </div>
-  );
-}
 
 interface Props {
   wsMessages: WsMessage[];

--- a/web-ui/src/types/index.ts
+++ b/web-ui/src/types/index.ts
@@ -199,13 +199,14 @@ export interface RunState {
   liveData: LiveDataPoint[];
   result: SingleTestResult | null;
   results: ParallelResults | null;
+  comparison: ComparisonResult | null;
   errorMsg: string;
 }
 
 export type RunAction =
   | { type: 'start'; progress: TestProgress }
   | { type: 'progress'; data: TestProgress }
-  | { type: 'complete'; data: { result?: SingleTestResult; results?: ParallelResults } }
+  | { type: 'complete'; data: { result?: SingleTestResult; results?: ParallelResults; comparison?: ComparisonResult } }
   | { type: 'error'; data: { message: string } };
 
 // ─── WebSocket ────────────────────────────────────────────────────────────
@@ -277,6 +278,55 @@ export interface SettingsForm {
   enablePerformanceSchema: boolean;
   debugOutputEnabled: boolean;
   autoSaveResults: boolean;
+  [key: string]: string | number | boolean;
+}
+
+// ─── Comparison Test ─────────────────────────────────────────────────────
+
+export interface ComparisonDelta {
+  meanDiff: number;
+  meanDiffPercent: number;
+  medianDiff: number;
+  medianDiffPercent: number;
+  p50Diff: number;
+  p50DiffPercent: number;
+  p95Diff: number;
+  p95DiffPercent: number;
+  p99Diff: number;
+  p99DiffPercent: number;
+  winner: 'A' | 'B' | 'tie';
+  summary: string;
+}
+
+export interface ComparisonResult {
+  resultA: SingleTestResult;
+  resultB: SingleTestResult;
+  delta: ComparisonDelta | null;
+  executionMode: 'sequential' | 'parallel';
+  testNameA: string;
+  testNameB: string;
+}
+
+export interface ComparisonTestForm {
+  connectionId: string;
+  executionMode: 'sequential' | 'parallel';
+  sqlModeA: 'library' | 'direct';
+  sqlIdA: string;
+  sqlTextA: string;
+  testNameA: string;
+  sqlModeB: 'library' | 'direct';
+  sqlIdB: string;
+  sqlTextB: string;
+  testNameB: string;
+  testIterations: number;
+  enableWarmup: boolean;
+  warmupPercentage: number;
+  removeOutliers: boolean;
+  outlierMethod: string;
+  enableExplainAnalyze: boolean;
+  enableOptimizerTrace: boolean;
+  enableBufferPoolMonitoring: boolean;
+  enablePerformanceSchema: boolean;
   [key: string]: string | number | boolean;
 }
 

--- a/web/routes/tests.ts
+++ b/web/routes/tests.ts
@@ -27,6 +27,7 @@ import { ParallelPerformanceTester } from '../../lib/testers/parallel-tester.js'
 import { createDbConfig } from '../../lib/config/database-configuration.js';
 import { createTestConfig } from '../../lib/config/test-configuration.js';
 import { validateQuery } from '../../lib/utils/validator.js';
+import { computeComparisonDelta } from '../../lib/utils/comparison-delta.js';
 import { validateId } from '../security/validate-id.js';
 import { asyncHandler } from '../middleware/async-handler.js';
 import type { DbConfig, TestConfig } from '../../lib/types/index.js';
@@ -92,6 +93,15 @@ interface SingleTestBody {
 /** Request body for parallel test */
 interface ParallelTestBody extends SingleTestBody {
   sqlIds?: string[];
+}
+
+/** Request body for comparison test */
+interface ComparisonTestBody extends SingleTestBody {
+  sqlTextA: string;
+  sqlTextB: string;
+  testNameA?: string;
+  testNameB?: string;
+  executionMode?: 'sequential' | 'parallel';
 }
 
 /** Error with an optional HTTP status code */
@@ -405,6 +415,142 @@ router.post('/parallel', async (req: Request, res: Response) => {
       if (tmpDirCreated && usedDir) {
         await fs.rm(usedDir, { recursive: true, force: true }).catch(() => { });
       }
+      releaseSemaphore();
+    }
+  });
+});
+
+// ─── Comparison test ────────────────────────────────────────────────────
+router.post('/comparison', async (req: Request, res: Response) => {
+  if (!acquireSemaphore()) {
+    res.status(429).json({
+      success: false,
+      error: `同時実行可能なテスト数の上限（${MAX_CONCURRENT_TESTS}）に達しています。しばらく待ってから再試行してください。`
+    });
+    return;
+  }
+
+  const {
+    sqlTextA, sqlTextB,
+    testNameA = 'Query A', testNameB = 'Query B',
+    executionMode = 'sequential',
+  } = req.body as ComparisonTestBody;
+
+  // Validate both queries
+  if (!sqlTextA?.trim() || !sqlTextB?.trim()) {
+    releaseSemaphore();
+    res.status(400).json({ success: false, error: 'Query A と Query B の両方を入力してください' });
+    return;
+  }
+
+  try {
+    validateQuery(sqlTextA.trim());
+    validateQuery(sqlTextB.trim());
+  } catch (validationErr) {
+    releaseSemaphore();
+    res.status(400).json({ success: false, error: `SQLバリデーションエラー: ${(validationErr as Error).message}` });
+    return;
+  }
+
+  let dbConfig: DbConfig;
+  let testConfig: TestConfig;
+  try {
+    ({ dbConfig, testConfig } = await buildConfigs(req.body as SingleTestBody));
+  } catch (configErr) {
+    releaseSemaphore();
+    if ((configErr as HttpError).status === 400) {
+      res.status(400).json({ success: false, error: (configErr as Error).message });
+      return;
+    }
+    if ((configErr as Error).message === '指定された接続が見つかりません') {
+      res.status(404).json({ success: false, error: (configErr as Error).message });
+      return;
+    }
+    res.status(500).json({ success: false, error: 'サーバーエラーが発生しました' });
+    return;
+  }
+
+  const testId = `comparison_${randomUUID()}`;
+  const wss = req.app.get('wss') as ExtendedWebSocketServer | undefined;
+
+  res.status(202).json({ success: true, data: { testId } });
+
+  setImmediate(async () => {
+    let testerA: MySQLPerformanceTester | null = null;
+    let testerB: MySQLPerformanceTester | null = null;
+    try {
+      if (executionMode === 'parallel') {
+        // Parallel: two independent tester instances running concurrently
+        testerA = new MySQLPerformanceTester(dbConfig, testConfig);
+        testerB = new MySQLPerformanceTester(dbConfig, testConfig);
+        testerA.on('progress', (data: Record<string, unknown>) =>
+          broadcast(wss, testId, 'progress', { ...data, phase: `queryA:${data.phase || ''}` }));
+        testerB.on('progress', (data: Record<string, unknown>) =>
+          broadcast(wss, testId, 'progress', { ...data, phase: `queryB:${data.phase || ''}` }));
+
+        await Promise.all([testerA.initialize(), testerB.initialize()]);
+        const [resultA, resultB] = await Promise.all([
+          testerA.executeTestWithWarmup(testNameA, sqlTextA.trim()),
+          testerB.executeTestWithWarmup(testNameB, sqlTextB.trim()),
+        ]);
+
+        const delta = (resultA.statistics && resultB.statistics)
+          ? computeComparisonDelta(resultA.statistics, resultB.statistics)
+          : null;
+
+        await fs.mkdir(RESULTS_DIR, { recursive: true });
+        const resultPath = path.join(RESULTS_DIR, `${testId}.json`);
+        await fs.writeFile(resultPath, JSON.stringify({
+          type: 'comparison', testId, executionMode,
+          testNameA, testNameB,
+          resultA, resultB, delta,
+        }, null, 2));
+
+        broadcast(wss, testId, 'complete', {
+          testId, executionMode, testNameA, testNameB,
+          resultA: serializeResult(resultA),
+          resultB: serializeResult(resultB),
+          delta,
+        });
+      } else {
+        // Sequential: single tester instance, A then B
+        testerA = new MySQLPerformanceTester(dbConfig, testConfig);
+        testerA.on('progress', (data: Record<string, unknown>) =>
+          broadcast(wss, testId, 'progress', { ...data, phase: `queryA:${data.phase || ''}` }));
+        await testerA.initialize();
+        const resultA = await testerA.executeTestWithWarmup(testNameA, sqlTextA.trim());
+
+        // Switch progress prefix for query B
+        testerA.removeAllListeners('progress');
+        testerA.on('progress', (data: Record<string, unknown>) =>
+          broadcast(wss, testId, 'progress', { ...data, phase: `queryB:${data.phase || ''}` }));
+        const resultB = await testerA.executeTestWithWarmup(testNameB, sqlTextB.trim());
+
+        const delta = (resultA.statistics && resultB.statistics)
+          ? computeComparisonDelta(resultA.statistics, resultB.statistics)
+          : null;
+
+        await fs.mkdir(RESULTS_DIR, { recursive: true });
+        const resultPath = path.join(RESULTS_DIR, `${testId}.json`);
+        await fs.writeFile(resultPath, JSON.stringify({
+          type: 'comparison', testId, executionMode,
+          testNameA, testNameB,
+          resultA, resultB, delta,
+        }, null, 2));
+
+        broadcast(wss, testId, 'complete', {
+          testId, executionMode, testNameA, testNameB,
+          resultA: serializeResult(resultA),
+          resultB: serializeResult(resultB),
+          delta,
+        });
+      }
+    } catch (err) {
+      console.error(`[test:${testId}] Error:`, (err as Error).message);
+      broadcast(wss, testId, 'error', { message: (err as Error).message });
+    } finally {
+      if (testerA) await testerA.cleanup().catch(() => { });
+      if (testerB) await testerB.cleanup().catch(() => { });
       releaseSemaphore();
     }
   });


### PR DESCRIPTION
## Summary
- 2つのSQLクエリを同一パラメータで実行し、結果をside-by-sideで比較する「A/B 比較モード」を追加
- 実行方式は **順次 (A→B)** と **並列 (A||B)** をユーザーが選択可能（キャッシュ影響の観点から両方必要）
- デルタサマリー（勝者 + Mean/P95/P99 の差分）、ヒストグラム重ね合わせ、パーセンタイル比較テーブルを実装

### 新規ファイル (8件)
| ファイル | 内容 |
|---------|------|
| `lib/utils/comparison-delta.ts` | デルタ計算の純粋関数 |
| `web-ui/src/pages/ComparisonTest.tsx` | 比較テストページ |
| `web-ui/src/components/DeltaSummaryBar.tsx` | 勝者 + デルタ表示バー |
| `web-ui/src/components/OverlaidHistogram.tsx` | 2分布の重ね合わせヒストグラム |
| `web-ui/src/components/ComparisonPercentilesTable.tsx` | パーセンタイル比較テーブル |
| `web-ui/src/components/HistogramChart.tsx` | SingleTestから抽出 |
| `web-ui/src/components/ExplainPanel.tsx` | SingleTestから抽出 |
| `web-ui/src/components/RecommendPanel.tsx` | SingleTestから抽出 |

### 変更ファイル (7件)
| ファイル | 変更内容 |
|---------|---------|
| `web/routes/tests.ts` | `POST /api/tests/comparison` エンドポイント追加 |
| `web-ui/src/types/index.ts` | ComparisonDelta, ComparisonResult, ComparisonTestForm 型追加 |
| `web-ui/src/api/client.ts` | `testsApi.runComparison()` 追加 |
| `web-ui/src/hooks/useTestExecution.ts` | comparison 状態 + WS メッセージ変換 |
| `web-ui/src/pages/SingleTest.tsx` | インラインコンポーネントを外部参照に変更 |
| `web-ui/src/pages/Reports.tsx` | comparison 型レポートの詳細表示対応 |
| `web-ui/src/App.tsx` | `/comparison` ルート + ナビゲーション追加 |

Closes #5

## Test plan
- [x] ESLint pass
- [x] TypeScript type check pass (backend + frontend)
- [x] Vite production build pass
- [x] API サーバー起動確認 (import エラーなし)
- [x] 比較ページ UI 表示確認 (設定パネル、実行方式トグル、Query A/B 入力)
- [x] バリデーション動作確認 (接続未選択時にエラー表示)
- [x] WebSocket 接続確認 (WS Connected 表示)
- [x] SingleTest ページのリグレッションなし確認
- [x] 全ページ遷移で console error なし
- [ ] 実際の MySQL 接続での A/B 比較テスト実行 (要 DB 環境)

> **Note:** 実際の DB 接続を使った E2E テストは未実施です。Docker Compose による自動テスト環境の整備を別 issue で検討予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)