### PR TITLE
feat: クエリ履歴タイムライン — 同一クエリの実行履歴とインデックス効果の可視化

### DIFF
--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -339,3 +339,44 @@ export interface PerformanceSchemaMetrics {
     tableScans: TableScanEntry[] | null;
     connections: Record<string, number> | null;
 }
+
+// ─── Query History ─────────────────────────────────────────────────────
+
+export interface QueryHistoryEntry {
+    testId: string;
+    testName: string;
+    timestamp: string;
+    statistics: StatisticsResult;
+    explainAccessType?: string;
+}
+
+export type QueryEventType =
+    | 'index_added'
+    | 'index_removed'
+    | 'schema_change'
+    | 'config_change'
+    | 'custom';
+
+export interface QueryEvent {
+    id: string;
+    queryFingerprint: string;
+    label: string;
+    type: QueryEventType;
+    timestamp: string;
+    createdAt: string;
+}
+
+export interface QueryFingerprintSummary {
+    queryFingerprint: string;
+    queryText: string;
+    latestTestName: string;
+    runCount: number;
+    latestRunAt: string;
+}
+
+export interface QueryTimeline {
+    queryFingerprint: string;
+    queryText: string;
+    entries: QueryHistoryEntry[];
+    events: QueryEvent[];
+}

--- a/lib/utils/query-fingerprint.ts
+++ b/lib/utils/query-fingerprint.ts
@@ -1,0 +1,73 @@
+/**
+ * query-fingerprint.ts - Normalize SQL and produce a stable hash
+ *
+ * The same logical query (differing only in whitespace, casing, or literal
+ * values) always maps to the same fingerprint, enabling history tracking
+ * across multiple test runs.
+ */
+
+import { createHash } from 'crypto';
+
+export interface QueryFingerprint {
+  /** SHA-256 hex, first 16 characters */
+  hash: string;
+  /** Whitespace-collapsed, lowercased, literals-replaced SQL */
+  normalized: string;
+}
+
+/**
+ * Normalize a SQL string for fingerprinting.
+ *
+ * Steps:
+ *  1. Trim leading/trailing whitespace
+ *  2. Strip SQL comments (block and line)
+ *  3. Replace quoted string literals with `?`
+ *  4. Replace numeric literals with `?`
+ *  5. Collapse whitespace sequences to a single space
+ *  6. Lowercase everything
+ *  7. Remove trailing semicolons
+ */
+function normalizeQuery(sql: string): string {
+  let s = sql.trim();
+
+  // Strip block comments /* ... */
+  s = s.replace(/\/\*[\s\S]*?\*\//g, ' ');
+
+  // Strip line comments -- ... and # ...
+  s = s.replace(/--.*/g, ' ');
+  s = s.replace(/#.*/g, ' ');
+
+  // Replace single-quoted string literals with ?
+  // Handles escaped quotes ('O''Brien' -> ?)
+  s = s.replace(/'(?:[^'\\]|\\.)*'/g, '?');
+
+  // Replace double-quoted string literals with ?
+  s = s.replace(/"(?:[^"\\]|\\.)*"/g, '?');
+
+  // Replace numeric literals (integers and decimals) with ?
+  // Negative sign is not included — it is an operator, not part of the literal
+  s = s.replace(/\b\d+(?:\.\d+)?\b/g, '?');
+
+  // Collapse whitespace
+  s = s.replace(/\s+/g, ' ').trim();
+
+  // Lowercase
+  s = s.toLowerCase();
+
+  // Remove trailing semicolons and trim again
+  s = s.replace(/;+\s*$/, '').trim();
+
+  return s;
+}
+
+/**
+ * Produce a fingerprint for the given SQL text.
+ *
+ * @param sql - Raw SQL string (may include comments, varying whitespace, etc.)
+ * @returns A fingerprint containing a 16-char hex hash and the normalized SQL
+ */
+export function fingerprintQuery(sql: string): QueryFingerprint {
+  const normalized = normalizeQuery(sql);
+  const hash = createHash('sha256').update(normalized).digest('hex').slice(0, 16);
+  return { hash, normalized };
+}

--- a/tests/utils/query-fingerprint.test.ts
+++ b/tests/utils/query-fingerprint.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { fingerprintQuery } from '../../lib/utils/query-fingerprint.js';
+
+describe('fingerprintQuery', () => {
+    it('returns a 16-char hex hash', () => {
+        const fp = fingerprintQuery('SELECT * FROM users');
+        expect(fp.hash).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    it('returns normalized SQL', () => {
+        const fp = fingerprintQuery('  SELECT  *  FROM  users  ;  ');
+        expect(fp.normalized).toBe('select * from users');
+    });
+
+    // ── Identity: same logical query → same hash ────────────────────────
+
+    it('produces same hash regardless of whitespace', () => {
+        const a = fingerprintQuery('SELECT * FROM users WHERE id = 1');
+        const b = fingerprintQuery('SELECT  *  FROM  users  WHERE  id  =  1');
+        const c = fingerprintQuery('SELECT\n*\nFROM\nusers\nWHERE\nid\n=\n1');
+        expect(a.hash).toBe(b.hash);
+        expect(a.hash).toBe(c.hash);
+    });
+
+    it('produces same hash regardless of casing', () => {
+        const a = fingerprintQuery('SELECT * FROM users');
+        const b = fingerprintQuery('select * from users');
+        const c = fingerprintQuery('Select * From Users');
+        expect(a.hash).toBe(b.hash);
+        expect(a.hash).toBe(c.hash);
+    });
+
+    it('produces same hash regardless of numeric literal values', () => {
+        const a = fingerprintQuery('SELECT * FROM users WHERE id = 1');
+        const b = fingerprintQuery('SELECT * FROM users WHERE id = 42');
+        const c = fingerprintQuery('SELECT * FROM users WHERE id = 9999');
+        expect(a.hash).toBe(b.hash);
+        expect(a.hash).toBe(c.hash);
+    });
+
+    it('produces same hash regardless of string literal values', () => {
+        const a = fingerprintQuery("SELECT * FROM users WHERE name = 'Alice'");
+        const b = fingerprintQuery("SELECT * FROM users WHERE name = 'Bob'");
+        expect(a.hash).toBe(b.hash);
+    });
+
+    it('produces same hash with or without trailing semicolons', () => {
+        const a = fingerprintQuery('SELECT 1');
+        const b = fingerprintQuery('SELECT 1;');
+        const c = fingerprintQuery('SELECT 1 ; ');
+        expect(a.hash).toBe(b.hash);
+        expect(a.hash).toBe(c.hash);
+    });
+
+    it('produces same hash ignoring comments', () => {
+        const a = fingerprintQuery('SELECT * FROM users');
+        const b = fingerprintQuery('/* test query */ SELECT * FROM users');
+        const c = fingerprintQuery('SELECT * FROM users -- fetch all');
+        expect(a.hash).toBe(b.hash);
+        expect(a.hash).toBe(c.hash);
+    });
+
+    // ── Differentiation: structurally different queries → different hash ─
+
+    it('produces different hash for structurally different queries', () => {
+        const a = fingerprintQuery('SELECT * FROM users');
+        const b = fingerprintQuery('SELECT * FROM orders');
+        expect(a.hash).not.toBe(b.hash);
+    });
+
+    it('produces different hash when WHERE clause differs structurally', () => {
+        const a = fingerprintQuery('SELECT * FROM users WHERE id = 1');
+        const b = fingerprintQuery('SELECT * FROM users WHERE name = 1');
+        expect(a.hash).not.toBe(b.hash);
+    });
+
+    it('produces different hash for SELECT vs INSERT', () => {
+        const a = fingerprintQuery('SELECT * FROM users');
+        const b = fingerprintQuery("INSERT INTO users VALUES (1, 'test')");
+        expect(a.hash).not.toBe(b.hash);
+    });
+
+    // ── Edge cases ──────────────────────────────────────────────────────
+
+    it('handles decimal literals', () => {
+        const a = fingerprintQuery('SELECT * FROM t WHERE price > 10.5');
+        const b = fingerprintQuery('SELECT * FROM t WHERE price > 99.99');
+        expect(a.hash).toBe(b.hash);
+    });
+
+    it('handles escaped quotes in strings', () => {
+        const fp = fingerprintQuery("SELECT * FROM t WHERE name = 'O\\'Brien'");
+        expect(fp.normalized).toContain('?');
+        expect(fp.normalized).not.toContain("o'brien");
+    });
+
+    it('handles double-quoted strings', () => {
+        const a = fingerprintQuery('SELECT * FROM t WHERE name = "Alice"');
+        const b = fingerprintQuery('SELECT * FROM t WHERE name = "Bob"');
+        expect(a.hash).toBe(b.hash);
+    });
+
+    it('handles empty-ish input gracefully', () => {
+        const fp = fingerprintQuery('   ');
+        expect(fp.hash).toMatch(/^[0-9a-f]{16}$/);
+        expect(fp.normalized).toBe('');
+    });
+});

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -11,6 +11,7 @@ import Reports from './pages/Reports';
 import Analytics from './pages/Analytics';
 import ComparisonTest from './pages/ComparisonTest';
 import Settings from './pages/Settings';
+import QueryHistory from './pages/QueryHistory';
 
 type NavItem =
   | { section: string; path?: undefined; icon?: undefined; label?: undefined }
@@ -27,6 +28,7 @@ const NAV: NavItem[] = [
   { section: 'Insights' },
   { path: '/reports', icon: '📋', label: 'レポート' },
   { path: '/analytics', icon: '📈', label: 'アナリティクス' },
+  { path: '/history', icon: '🕐', label: 'クエリ履歴' },
   { section: 'System' },
   { path: '/settings', icon: '⚙️', label: '設定' },
 ];
@@ -66,6 +68,7 @@ const PAGE_META: Record<string, { title: string; subtitle?: string }> = {
   '/comparison': { title: 'A/B 比較テスト', subtitle: '2つのクエリの性能を並べて比較' },
   '/reports': { title: 'レポート', subtitle: '過去のテスト結果を閲覧・エクスポート' },
   '/analytics': { title: 'アナリティクス', subtitle: 'トレンド分析と比較' },
+  '/history': { title: 'クエリ履歴', subtitle: '同一クエリの実行履歴と変更効果の可視化' },
   '/settings': { title: '設定', subtitle: 'デフォルト設定の管理' },
 };
 
@@ -115,6 +118,7 @@ export default function App() {
               <Route path="/comparison" element={<ComparisonTest wsMessages={wsMessages} subscribeTestId={subscribeTestId} />} />
               <Route path="/reports" element={<Reports />} />
               <Route path="/analytics" element={<Analytics />} />
+              <Route path="/history" element={<QueryHistory />} />
               <Route path="/settings" element={<Settings />} />
             </Routes>
           </main>

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -12,6 +12,11 @@ import type {
   SqlFilters,
   ReportSummary,
   ReportDetail,
+  QueryFingerprintSummary,
+  QueryTimeline,
+  HistoryComparison,
+  QueryEvent,
+  CreateEventInput,
 } from '../types';
 
 interface ApiResponse<T> {
@@ -83,4 +88,20 @@ export const reportsApi = {
   get: (id: string): Promise<ReportDetail> => get<ReportDetail>(`/reports/${id}`),
   exportUrl: (id: string, format: string): string =>
     `${BASE_URL}/reports/${encodeURIComponent(id)}/export?format=${encodeURIComponent(format)}`,
+};
+
+// ─── History ──────────────────────────────────────────────────────────────
+export const historyApi = {
+  fingerprints: (): Promise<QueryFingerprintSummary[]> =>
+    get<QueryFingerprintSummary[]>('/history/fingerprints'),
+  timeline: (fp: string): Promise<QueryTimeline> =>
+    get<QueryTimeline>(`/history/${encodeURIComponent(fp)}`),
+  compare: (fp: string, before: string, after: string): Promise<HistoryComparison> =>
+    get<HistoryComparison>(
+      `/history/${encodeURIComponent(fp)}/compare?before=${encodeURIComponent(before)}&after=${encodeURIComponent(after)}`
+    ),
+  createEvent: (data: CreateEventInput): Promise<QueryEvent> =>
+    post<QueryEvent>('/history/events', data),
+  deleteEvent: (id: string): Promise<void> =>
+    del<void>(`/history/events/${id}`),
 };

--- a/web-ui/src/components/EventForm.tsx
+++ b/web-ui/src/components/EventForm.tsx
@@ -1,0 +1,89 @@
+/**
+ * EventForm - Inline form to add timeline event annotations
+ * (e.g., "Index added on users.email")
+ */
+import { useState } from 'react';
+import type { QueryEventType } from '../types';
+
+interface Props {
+  queryFingerprint: string;
+  onSubmit: (data: { label: string; type: QueryEventType; timestamp: string }) => Promise<void>;
+}
+
+const EVENT_TYPES: { value: QueryEventType; label: string }[] = [
+  { value: 'index_added', label: 'Index Added' },
+  { value: 'index_removed', label: 'Index Removed' },
+  { value: 'schema_change', label: 'Schema Change' },
+  { value: 'config_change', label: 'Config Change' },
+  { value: 'custom', label: 'Custom' },
+];
+
+function nowLocal(): string {
+  const d = new Date();
+  d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+  return d.toISOString().slice(0, 16);
+}
+
+export default function EventForm({ onSubmit }: Props) {
+  const [label, setLabel] = useState('');
+  const [type, setType] = useState<QueryEventType>('index_added');
+  const [timestamp, setTimestamp] = useState(nowLocal);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!label.trim()) return;
+    setSubmitting(true);
+    try {
+      await onSubmit({
+        label: label.trim(),
+        type,
+        timestamp: new Date(timestamp).toISOString(),
+      });
+      setLabel('');
+      setTimestamp(nowLocal());
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{
+      display: 'grid',
+      gridTemplateColumns: '1fr auto auto auto',
+      gap: 'var(--space-2)',
+      alignItems: 'end',
+    }}>
+      <div>
+        <label className="form-label">Event Label</label>
+        <input
+          className="form-input"
+          value={label}
+          onChange={e => setLabel(e.target.value)}
+          placeholder="e.g., Added index on users.email"
+          required
+        />
+      </div>
+      <div>
+        <label className="form-label">Type</label>
+        <select className="form-input" value={type} onChange={e => setType(e.target.value as QueryEventType)}>
+          {EVENT_TYPES.map(t => (
+            <option key={t.value} value={t.value}>{t.label}</option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="form-label">Timestamp</label>
+        <input
+          className="form-input"
+          type="datetime-local"
+          value={timestamp}
+          onChange={e => setTimestamp(e.target.value)}
+        />
+      </div>
+      <button type="submit" className="btn btn-primary" disabled={submitting || !label.trim()}>
+        {submitting ? '...' : 'Add'}
+      </button>
+    </form>
+  );
+}

--- a/web-ui/src/components/TimelineChart.tsx
+++ b/web-ui/src/components/TimelineChart.tsx
@@ -1,0 +1,107 @@
+/**
+ * TimelineChart - Line chart showing query metrics over time
+ * with event annotations (e.g., index added) as reference lines
+ */
+import {
+  LineChart, Line, XAxis, YAxis, CartesianGrid,
+  Tooltip, Legend, ReferenceLine, ResponsiveContainer,
+} from 'recharts';
+import type { QueryHistoryEntry, QueryEvent } from '../types';
+
+interface Props {
+  entries: QueryHistoryEntry[];
+  events: QueryEvent[];
+}
+
+const EVENT_COLORS: Record<string, string> = {
+  index_added: 'var(--color-success)',
+  index_removed: 'var(--color-danger)',
+  schema_change: 'var(--color-warning)',
+  config_change: 'var(--color-accent)',
+  custom: 'var(--color-text-muted)',
+};
+
+function formatDate(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return `${d.getMonth() + 1}/${d.getDate()} ${d.getHours()}:${String(d.getMinutes()).padStart(2, '0')}`;
+  } catch {
+    return iso;
+  }
+}
+
+export default function TimelineChart({ entries, events }: Props) {
+  if (entries.length === 0) {
+    return <div className="empty-state"><p>履歴データがありません</p></div>;
+  }
+
+  const data = entries.map(e => ({
+    timestamp: e.timestamp,
+    label: formatDate(e.timestamp),
+    mean: e.statistics?.basic?.mean ?? null,
+    p50: e.statistics?.percentiles?.p50 ?? null,
+    p95: e.statistics?.percentiles?.p95 ?? null,
+    p99: e.statistics?.percentiles?.p99 ?? null,
+  }));
+
+  // Map events to their x-axis positions (closest entry timestamp)
+  const eventLines = events.map(ev => {
+    const evTime = new Date(ev.timestamp).getTime();
+    let closestLabel = data[0]?.label ?? '';
+    let minDist = Infinity;
+    for (const d of data) {
+      const dist = Math.abs(new Date(d.timestamp).getTime() - evTime);
+      if (dist < minDist) {
+        minDist = dist;
+        closestLabel = d.label;
+      }
+    }
+    return { ...ev, closestLabel };
+  });
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={data} margin={{ top: 10, right: 20, left: 0, bottom: 5 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+        <XAxis
+          dataKey="label"
+          tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
+        />
+        <YAxis
+          tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
+          label={{ value: 'ms', position: 'insideLeft', style: { fill: 'var(--color-text-muted)', fontSize: 11 } }}
+        />
+        <Tooltip
+          contentStyle={{
+            background: 'var(--color-surface-2)',
+            border: '1px solid var(--color-border)',
+            borderRadius: 6,
+          }}
+          formatter={(value: number) => [`${value?.toFixed(2)} ms`]}
+        />
+        <Legend wrapperStyle={{ fontSize: 12 }} />
+
+        <Line type="monotone" dataKey="mean" stroke="var(--color-accent)" name="Mean" dot={{ r: 3 }} strokeWidth={2} connectNulls />
+        <Line type="monotone" dataKey="p50" stroke="#60a5fa" name="P50" dot={{ r: 2 }} strokeWidth={1.5} connectNulls />
+        <Line type="monotone" dataKey="p95" stroke="#f59e0b" name="P95" dot={{ r: 2 }} strokeWidth={1.5} connectNulls />
+        <Line type="monotone" dataKey="p99" stroke="#ef4444" name="P99" dot={{ r: 2 }} strokeWidth={1.5} connectNulls />
+
+        {eventLines.map(ev => (
+          <ReferenceLine
+            key={ev.id}
+            x={ev.closestLabel}
+            stroke={EVENT_COLORS[ev.type] || 'var(--color-text-muted)'}
+            strokeDasharray="5 3"
+            strokeWidth={2}
+            label={{
+              value: ev.label,
+              position: 'top',
+              fill: EVENT_COLORS[ev.type] || 'var(--color-text-muted)',
+              fontSize: 11,
+            }}
+          />
+        ))}
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/web-ui/src/pages/QueryHistory.tsx
+++ b/web-ui/src/pages/QueryHistory.tsx
@@ -1,0 +1,269 @@
+/**
+ * QueryHistory - Timeline view for the same query across multiple test runs.
+ * Supports event annotations (e.g., index added) and before/after comparison.
+ */
+import { useState, useEffect, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { historyApi } from '../api/client';
+import TimelineChart from '../components/TimelineChart';
+import EventForm from '../components/EventForm';
+import DeltaSummaryBar from '../components/DeltaSummaryBar';
+import type {
+  QueryFingerprintSummary,
+  QueryTimeline,
+  HistoryComparison,
+  QueryEventType,
+} from '../types';
+
+export default function QueryHistory() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [fingerprints, setFingerprints] = useState<QueryFingerprintSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedFp, setSelectedFp] = useState<string | null>(searchParams.get('q'));
+  const [timeline, setTimeline] = useState<QueryTimeline | null>(null);
+  const [timelineLoading, setTimelineLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  // Before/After comparison state
+  const [beforeId, setBeforeId] = useState('');
+  const [afterId, setAfterId] = useState('');
+  const [comparison, setComparison] = useState<HistoryComparison | null>(null);
+  const [compareLoading, setCompareLoading] = useState(false);
+
+  // SQL display toggle
+  const [showSql, setShowSql] = useState(false);
+
+  // Load fingerprint list
+  useEffect(() => {
+    historyApi.fingerprints()
+      .then(data => { setFingerprints(data); setLoading(false); })
+      .catch(e => { setError((e as Error).message); setLoading(false); });
+  }, []);
+
+  // Load timeline when selected
+  const loadTimeline = useCallback(async (fp: string) => {
+    setSelectedFp(fp);
+    setSearchParams({ q: fp });
+    setTimeline(null);
+    setComparison(null);
+    setBeforeId('');
+    setAfterId('');
+    setTimelineLoading(true);
+    try {
+      const data = await historyApi.timeline(fp);
+      setTimeline(data);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setTimelineLoading(false);
+    }
+  }, [setSearchParams]);
+
+  // Auto-load timeline from URL param
+  useEffect(() => {
+    const q = searchParams.get('q');
+    if (q && !timeline && !timelineLoading) {
+      loadTimeline(q);
+    }
+  }, [searchParams, timeline, timelineLoading, loadTimeline]);
+
+  // Add event handler
+  const handleAddEvent = async (data: { label: string; type: QueryEventType; timestamp: string }) => {
+    if (!selectedFp) return;
+    await historyApi.createEvent({ queryFingerprint: selectedFp, ...data });
+    // Reload timeline
+    await loadTimeline(selectedFp);
+  };
+
+  // Delete event handler
+  const handleDeleteEvent = async (id: string) => {
+    await historyApi.deleteEvent(id);
+    if (selectedFp) await loadTimeline(selectedFp);
+  };
+
+  // Compare handler
+  const handleCompare = async () => {
+    if (!selectedFp || !beforeId || !afterId) return;
+    setCompareLoading(true);
+    setComparison(null);
+    try {
+      const data = await historyApi.compare(selectedFp, beforeId, afterId);
+      setComparison(data);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setCompareLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '300px 1fr', gap: 'var(--space-5)', alignItems: 'start' }}>
+
+      {/* Left panel: fingerprint list */}
+      <div>
+        <div className="section-title">Query Fingerprints</div>
+        {error && <div className="alert alert-error">{error}</div>}
+        {loading ? (
+          <div className="empty-state"><div className="spinner spinner-lg" /></div>
+        ) : fingerprints.length === 0 ? (
+          <div className="empty-state">
+            <div className="empty-icon">🔍</div>
+            <p>履歴データがありません</p>
+            <p className="text-xs text-muted">テストを実行すると自動的に表示されます</p>
+          </div>
+        ) : (
+          <div style={{ display: 'grid', gap: 'var(--space-2)' }}>
+            {fingerprints.map(fp => (
+              <div
+                key={fp.queryFingerprint}
+                className="card"
+                style={{
+                  cursor: 'pointer',
+                  border: selectedFp === fp.queryFingerprint ? '1px solid var(--color-accent)' : undefined,
+                }}
+                onClick={() => loadTimeline(fp.queryFingerprint)}
+              >
+                <div className="text-sm truncate" style={{ fontWeight: 500, marginBottom: 4 }}>
+                  {fp.latestTestName || fp.queryFingerprint}
+                </div>
+                <div className="text-xs text-muted" style={{ fontFamily: 'var(--font-mono)', marginBottom: 4 }}>
+                  {fp.queryText.length > 60 ? fp.queryText.slice(0, 60) + '...' : fp.queryText}
+                </div>
+                <div className="flex items-center gap-2" style={{ fontSize: 'var(--text-xs)', color: 'var(--color-text-muted)' }}>
+                  <span>{fp.runCount} runs</span>
+                  <span>|</span>
+                  <span>{new Date(fp.latestRunAt).toLocaleDateString('ja-JP')}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Right panel: timeline detail */}
+      <div>
+        {!selectedFp ? (
+          <div className="empty-state">
+            <div className="empty-icon">📊</div>
+            <p>左のリストからクエリを選択してください</p>
+          </div>
+        ) : timelineLoading ? (
+          <div className="empty-state"><div className="spinner spinner-lg" /></div>
+        ) : timeline ? (
+          <div style={{ display: 'grid', gap: 'var(--space-4)' }}>
+
+            {/* SQL text (collapsible) */}
+            <div className="card">
+              <div
+                style={{ cursor: 'pointer', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+                onClick={() => setShowSql(!showSql)}
+              >
+                <div className="section-title" style={{ margin: 0 }}>SQL</div>
+                <span className="text-xs text-muted">{showSql ? '▲ hide' : '▼ show'}</span>
+              </div>
+              {showSql && (
+                <pre style={{
+                  marginTop: 'var(--space-3)',
+                  padding: 'var(--space-3)',
+                  background: 'var(--color-surface-2)',
+                  borderRadius: 6,
+                  fontSize: 'var(--text-xs)',
+                  overflow: 'auto',
+                  maxHeight: 200,
+                }}>{timeline.queryText}</pre>
+              )}
+            </div>
+
+            {/* Timeline chart */}
+            <div className="card">
+              <div className="section-title">Performance Timeline ({timeline.entries.length} runs)</div>
+              <TimelineChart entries={timeline.entries} events={timeline.events} />
+            </div>
+
+            {/* Event annotations */}
+            <div className="card">
+              <div className="section-title">Events</div>
+              {timeline.events.length > 0 && (
+                <div style={{ marginBottom: 'var(--space-3)' }}>
+                  <table style={{ width: '100%', fontSize: 'var(--text-xs)' }}>
+                    <thead>
+                      <tr>
+                        <th style={{ textAlign: 'left', padding: '4px 8px' }}>Label</th>
+                        <th style={{ textAlign: 'left', padding: '4px 8px' }}>Type</th>
+                        <th style={{ textAlign: 'left', padding: '4px 8px' }}>Timestamp</th>
+                        <th style={{ padding: '4px 8px' }}></th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {timeline.events.map(ev => (
+                        <tr key={ev.id}>
+                          <td style={{ padding: '4px 8px' }}>{ev.label}</td>
+                          <td style={{ padding: '4px 8px' }}>
+                            <span className="badge badge-blue">{ev.type.replace('_', ' ')}</span>
+                          </td>
+                          <td style={{ padding: '4px 8px' }}>{new Date(ev.timestamp).toLocaleString('ja-JP')}</td>
+                          <td style={{ padding: '4px 8px', textAlign: 'right' }}>
+                            <button
+                              className="btn btn-sm"
+                              style={{ fontSize: 'var(--text-xs)', padding: '2px 8px' }}
+                              onClick={() => handleDeleteEvent(ev.id)}
+                            >
+                              Delete
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+              <EventForm queryFingerprint={selectedFp} onSubmit={handleAddEvent} />
+            </div>
+
+            {/* Before/After comparison */}
+            {timeline.entries.length >= 2 && (
+              <div className="card">
+                <div className="section-title">Before / After Comparison</div>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr auto', gap: 'var(--space-2)', alignItems: 'end', marginBottom: 'var(--space-3)' }}>
+                  <div>
+                    <label className="form-label">Before</label>
+                    <select className="form-input" value={beforeId} onChange={e => setBeforeId(e.target.value)}>
+                      <option value="">-- select --</option>
+                      {timeline.entries.map(e => (
+                        <option key={e.testId} value={e.testId}>
+                          {new Date(e.timestamp).toLocaleString('ja-JP')} ({e.testName})
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label className="form-label">After</label>
+                    <select className="form-input" value={afterId} onChange={e => setAfterId(e.target.value)}>
+                      <option value="">-- select --</option>
+                      {timeline.entries.map(e => (
+                        <option key={e.testId} value={e.testId}>
+                          {new Date(e.timestamp).toLocaleString('ja-JP')} ({e.testName})
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <button
+                    className="btn btn-primary"
+                    disabled={!beforeId || !afterId || beforeId === afterId || compareLoading}
+                    onClick={handleCompare}
+                  >
+                    {compareLoading ? '...' : 'Compare'}
+                  </button>
+                </div>
+
+                {comparison?.delta && (
+                  <DeltaSummaryBar delta={comparison.delta} nameA="Before" nameB="After" />
+                )}
+              </div>
+            )}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/web-ui/src/types/index.ts
+++ b/web-ui/src/types/index.ts
@@ -338,3 +338,57 @@ export interface StatCardItem {
   unit: string;
   highlight?: boolean;
 }
+
+// ─── Query History ──────────────────────────────────────────────────────
+
+export type QueryEventType =
+  | 'index_added'
+  | 'index_removed'
+  | 'schema_change'
+  | 'config_change'
+  | 'custom';
+
+export interface QueryFingerprintSummary {
+  queryFingerprint: string;
+  queryText: string;
+  latestTestName: string;
+  runCount: number;
+  latestRunAt: string;
+}
+
+export interface QueryHistoryEntry {
+  testId: string;
+  testName: string;
+  timestamp: string;
+  statistics: Statistics;
+  explainAccessType?: string;
+}
+
+export interface QueryEvent {
+  id: string;
+  queryFingerprint: string;
+  label: string;
+  type: QueryEventType;
+  timestamp: string;
+  createdAt: string;
+}
+
+export interface QueryTimeline {
+  queryFingerprint: string;
+  queryText: string;
+  entries: QueryHistoryEntry[];
+  events: QueryEvent[];
+}
+
+export interface HistoryComparison {
+  before: Statistics;
+  after: Statistics;
+  delta: ComparisonDelta;
+}
+
+export interface CreateEventInput {
+  queryFingerprint: string;
+  label: string;
+  type: QueryEventType;
+  timestamp?: string;
+}

--- a/web/routes/history.ts
+++ b/web/routes/history.ts
@@ -1,0 +1,273 @@
+/**
+ * history.ts - Query history routes
+ *
+ * GET  /api/history/fingerprints             -- List distinct query fingerprints
+ * GET  /api/history/:fingerprint             -- Timeline for a single query
+ * GET  /api/history/:fingerprint/compare     -- Before/After delta comparison
+ * POST /api/history/events                   -- Create a timeline event
+ * DELETE /api/history/events/:id             -- Delete a timeline event
+ */
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { fingerprintQuery } from '../../lib/utils/query-fingerprint.js';
+import { computeComparisonDelta } from '../../lib/utils/comparison-delta.js';
+import * as eventsStore from '../store/events-store.js';
+import { asyncHandler } from '../middleware/async-handler.js';
+import type { QueryFingerprintSummary, QueryHistoryEntry, QueryEventType } from '../../lib/types/index.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const RESULTS_DIR: string = path.join(__dirname, '..', '..', 'performance_results');
+
+const router: Router = Router();
+
+// ─── Helpers ────────────────────────────────────────────────────────────
+
+interface ParsedSingleResult {
+  testId: string;
+  testName: string;
+  queryFingerprint?: string;
+  queryNormalized?: string;
+  result: {
+    query?: string;
+    timestamp?: string;
+    statistics?: Record<string, unknown>;
+    explainAnalyze?: { data?: Record<string, unknown> };
+    [key: string]: unknown;
+  };
+}
+
+/**
+ * Scan performance_results/ and return parsed single-test results.
+ * Parallel and comparison results are excluded (they use different shapes).
+ */
+async function loadSingleResults(): Promise<ParsedSingleResult[]> {
+  await fs.mkdir(RESULTS_DIR, { recursive: true });
+  const files = await fs.readdir(RESULTS_DIR);
+  const jsonFiles = files.filter(f => f.startsWith('test_') && f.endsWith('.json'));
+
+  const results: ParsedSingleResult[] = [];
+
+  await Promise.all(jsonFiles.map(async (file) => {
+    try {
+      const raw = await fs.readFile(path.join(RESULTS_DIR, file), 'utf8');
+      const data = JSON.parse(raw) as ParsedSingleResult;
+      if (data.result) results.push(data);
+    } catch {
+      // Skip malformed files
+    }
+  }));
+
+  return results;
+}
+
+/**
+ * Resolve the fingerprint for a result.
+ * Uses the stored queryFingerprint if available, otherwise computes lazily.
+ */
+function resolveFingerprint(r: ParsedSingleResult): string | null {
+  if (r.queryFingerprint) return r.queryFingerprint;
+  const sql = r.result?.query;
+  if (!sql) return null;
+  return fingerprintQuery(sql).hash;
+}
+
+// ─── GET /fingerprints ──────────────────────────────────────────────────
+
+router.get('/fingerprints', asyncHandler(async (_req: Request, res: Response) => {
+  const results = await loadSingleResults();
+
+  // Group by fingerprint
+  const map = new Map<string, {
+    queryText: string;
+    latestTestName: string;
+    latestRunAt: string;
+    runCount: number;
+  }>();
+
+  for (const r of results) {
+    const fp = resolveFingerprint(r);
+    if (!fp) continue;
+
+    const timestamp = r.result.timestamp || '';
+    const existing = map.get(fp);
+
+    if (!existing) {
+      map.set(fp, {
+        queryText: r.result.query || '',
+        latestTestName: r.testName || '',
+        latestRunAt: timestamp,
+        runCount: 1,
+      });
+    } else {
+      existing.runCount++;
+      if (timestamp > existing.latestRunAt) {
+        existing.latestRunAt = timestamp;
+        existing.latestTestName = r.testName || '';
+        existing.queryText = r.result.query || existing.queryText;
+      }
+    }
+  }
+
+  const summaries: QueryFingerprintSummary[] = Array.from(map.entries())
+    .map(([queryFingerprint, v]) => ({
+      queryFingerprint,
+      queryText: v.queryText,
+      latestTestName: v.latestTestName,
+      runCount: v.runCount,
+      latestRunAt: v.latestRunAt,
+    }))
+    .sort((a, b) => b.latestRunAt.localeCompare(a.latestRunAt));
+
+  res.json({ success: true, data: summaries });
+}));
+
+// ─── GET /:fingerprint ──────────────────────────────────────────────────
+
+router.get('/:fingerprint', asyncHandler(async (req: Request, res: Response) => {
+  const fp = req.params.fingerprint as string;
+  if (!fp || !/^[0-9a-f]{16}$/.test(fp)) {
+    res.status(400).json({ success: false, error: '不正なフィンガープリントです' });
+    return;
+  }
+
+  const results = await loadSingleResults();
+  const entries: QueryHistoryEntry[] = [];
+  let queryText = '';
+
+  for (const r of results) {
+    const rFp = resolveFingerprint(r);
+    if (rFp !== fp) continue;
+
+    if (!queryText && r.result.query) queryText = r.result.query;
+
+    // Extract EXPLAIN access type if available
+    let explainAccessType: string | undefined;
+    try {
+      const explainData = r.result.explainAnalyze?.data as Record<string, unknown> | undefined;
+      if (explainData?.query_block) {
+        const qb = explainData.query_block as Record<string, unknown>;
+        const table = qb.table as Record<string, unknown> | undefined;
+        if (table?.access_type) explainAccessType = String(table.access_type);
+      }
+    } catch { /* ignore */ }
+
+    if (r.result.statistics) {
+      entries.push({
+        testId: r.testId,
+        testName: r.testName,
+        timestamp: r.result.timestamp || '',
+        statistics: r.result.statistics as unknown as QueryHistoryEntry['statistics'],
+        explainAccessType,
+      });
+    }
+  }
+
+  entries.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+
+  const events = await eventsStore.listByFingerprint(fp);
+
+  res.json({
+    success: true,
+    data: { queryFingerprint: fp, queryText, entries, events },
+  });
+}));
+
+// ─── GET /:fingerprint/compare ──────────────────────────────────────────
+
+router.get('/:fingerprint/compare', asyncHandler(async (req: Request, res: Response) => {
+  const { before, after } = req.query as { before?: string; after?: string };
+  if (!before || !after) {
+    res.status(400).json({ success: false, error: 'before と after のtestIdを指定してください' });
+    return;
+  }
+
+  // Read both result files
+  async function readStats(testId: string) {
+    const filePath = path.join(RESULTS_DIR, `${testId}.json`);
+    const raw = await fs.readFile(filePath, 'utf8');
+    const data = JSON.parse(raw) as ParsedSingleResult;
+    return data.result?.statistics;
+  }
+
+  try {
+    const [statsBefore, statsAfter] = await Promise.all([
+      readStats(before),
+      readStats(after),
+    ]);
+
+    if (!statsBefore || !statsAfter) {
+      res.status(400).json({ success: false, error: '統計データが見つかりません' });
+      return;
+    }
+
+    const delta = computeComparisonDelta(
+      statsBefore as Parameters<typeof computeComparisonDelta>[0],
+      statsAfter as Parameters<typeof computeComparisonDelta>[0],
+    );
+
+    res.json({
+      success: true,
+      data: { before: statsBefore, after: statsAfter, delta },
+    });
+  } catch {
+    res.status(404).json({ success: false, error: '結果ファイルが見つかりません' });
+  }
+}));
+
+// ─── POST /events ───────────────────────────────────────────────────────
+
+const VALID_EVENT_TYPES = new Set<QueryEventType>([
+  'index_added', 'index_removed', 'schema_change', 'config_change', 'custom',
+]);
+
+router.post('/events', asyncHandler(async (req: Request, res: Response) => {
+  const { queryFingerprint, label, type, timestamp } = req.body as {
+    queryFingerprint?: string;
+    label?: string;
+    type?: string;
+    timestamp?: string;
+  };
+
+  if (!queryFingerprint || !label || !type) {
+    res.status(400).json({ success: false, error: 'queryFingerprint, label, type は必須です' });
+    return;
+  }
+  if (!VALID_EVENT_TYPES.has(type as QueryEventType)) {
+    res.status(400).json({ success: false, error: `不正なイベントタイプです: ${type}` });
+    return;
+  }
+
+  const event = await eventsStore.create({
+    queryFingerprint,
+    label,
+    type: type as QueryEventType,
+    timestamp,
+  });
+
+  res.status(201).json({ success: true, data: event });
+}));
+
+// ─── DELETE /events/:id ─────────────────────────────────────────────────
+
+router.delete('/events/:id', asyncHandler(async (req: Request, res: Response) => {
+  const id = req.params.id as string;
+  if (!id) {
+    res.status(400).json({ success: false, error: 'イベントIDが指定されていません' });
+    return;
+  }
+
+  const deleted = await eventsStore.remove(id);
+  if (!deleted) {
+    res.status(404).json({ success: false, error: 'イベントが見つかりません' });
+    return;
+  }
+
+  res.json({ success: true });
+}));
+
+export default router;

--- a/web/routes/tests.ts
+++ b/web/routes/tests.ts
@@ -28,6 +28,7 @@ import { createDbConfig } from '../../lib/config/database-configuration.js';
 import { createTestConfig } from '../../lib/config/test-configuration.js';
 import { validateQuery } from '../../lib/utils/validator.js';
 import { computeComparisonDelta } from '../../lib/utils/comparison-delta.js';
+import { fingerprintQuery } from '../../lib/utils/query-fingerprint.js';
 import { validateId } from '../security/validate-id.js';
 import { asyncHandler } from '../middleware/async-handler.js';
 import type { DbConfig, TestConfig } from '../../lib/types/index.js';
@@ -285,10 +286,15 @@ router.post('/single', async (req: Request, res: Response) => {
 
       const result = await tester.executeTestWithWarmup(testName, sqlText.trim());
 
-      // Save result
+      // Save result with query fingerprint for history tracking
+      const fingerprint = fingerprintQuery(sqlText.trim());
       await fs.mkdir(RESULTS_DIR, { recursive: true });
       const resultPath = path.join(RESULTS_DIR, `${testId}.json`);
-      await fs.writeFile(resultPath, JSON.stringify({ testId, testName, result }, null, 2));
+      await fs.writeFile(resultPath, JSON.stringify({
+        testId, testName, result,
+        queryFingerprint: fingerprint.hash,
+        queryNormalized: fingerprint.normalized,
+      }, null, 2));
 
       broadcast(wss, testId, 'complete', {
         testId,
@@ -498,11 +504,14 @@ router.post('/comparison', async (req: Request, res: Response) => {
           ? computeComparisonDelta(resultA.statistics, resultB.statistics)
           : null;
 
+        const fpA = fingerprintQuery(sqlTextA.trim());
+        const fpB = fingerprintQuery(sqlTextB.trim());
         await fs.mkdir(RESULTS_DIR, { recursive: true });
         const resultPath = path.join(RESULTS_DIR, `${testId}.json`);
         await fs.writeFile(resultPath, JSON.stringify({
           type: 'comparison', testId, executionMode,
           testNameA, testNameB,
+          queryFingerprintA: fpA.hash, queryFingerprintB: fpB.hash,
           resultA, resultB, delta,
         }, null, 2));
 
@@ -530,11 +539,14 @@ router.post('/comparison', async (req: Request, res: Response) => {
           ? computeComparisonDelta(resultA.statistics, resultB.statistics)
           : null;
 
+        const fpA = fingerprintQuery(sqlTextA.trim());
+        const fpB = fingerprintQuery(sqlTextB.trim());
         await fs.mkdir(RESULTS_DIR, { recursive: true });
         const resultPath = path.join(RESULTS_DIR, `${testId}.json`);
         await fs.writeFile(resultPath, JSON.stringify({
           type: 'comparison', testId, executionMode,
           testNameA, testNameB,
+          queryFingerprintA: fpA.hash, queryFingerprintB: fpB.hash,
           resultA, resultB, delta,
         }, null, 2));
 

--- a/web/server.ts
+++ b/web/server.ts
@@ -31,6 +31,7 @@ import connectionsRouter from './routes/connections.js';
 import sqlLibraryRouter from './routes/sql-library.js';
 import testsRouter from './routes/tests.js';
 import reportsRouter from './routes/reports.js';
+import historyRouter from './routes/history.js';
 import { errorHandler } from './middleware/error-handler.js';
 
 /** Extended WebSocket with subscription management */
@@ -156,6 +157,7 @@ app.use('/api/sql', sqlLibraryRouter);
 // Apply rate limit to test execution endpoints
 app.use('/api/tests', testRateLimit, testsRouter);
 app.use('/api/reports', reportsRouter);
+app.use('/api/history', historyRouter);
 
 // ─── Health check ────────────────────────────────────────────────────────
 app.get('/api/health', (_req: Request, res: Response) => {

--- a/web/store/events-store.ts
+++ b/web/store/events-store.ts
@@ -1,0 +1,107 @@
+/**
+ * EventsStore - JSON file persistence for query timeline events
+ * Saves event annotations (e.g., "index added") in web/data/query-events.json
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { randomUUID } from 'crypto';
+import type { QueryEvent, QueryEventType } from '../../lib/types/index.js';
+
+// In-process mutex to prevent write conflicts
+let _lock: Promise<unknown> = Promise.resolve();
+function withLock<T>(fn: () => Promise<T>): Promise<T> {
+  const next = _lock.then(fn);
+  _lock = next.catch(() => {});
+  return next;
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = path.join(__dirname, '..', 'data');
+const STORE_FILE = path.join(DATA_DIR, 'query-events.json');
+
+async function writeAtomic(filePath: string, data: QueryEvent[]): Promise<void> {
+  const tmp = filePath + '.tmp';
+  await fs.writeFile(tmp, JSON.stringify(data, null, 2), 'utf8');
+  await fs.rename(tmp, filePath);
+}
+
+async function safeReadJson(filePath: string): Promise<QueryEvent[]> {
+  const raw = await fs.readFile(filePath, 'utf8');
+  try {
+    return JSON.parse(raw) as QueryEvent[];
+  } catch {
+    const backup = `${filePath}.corrupt_${Date.now()}`;
+    await fs.rename(filePath, backup).catch(() => {});
+    console.error(`[EventsStore] JSON parse failed. Backed up to ${backup}. Resetting.`);
+    await fs.writeFile(filePath, '[]', 'utf8').catch(() => {});
+    return [];
+  }
+}
+
+async function ensureStore(): Promise<void> {
+  await fs.mkdir(DATA_DIR, { recursive: true });
+  try {
+    await fs.access(STORE_FILE);
+  } catch {
+    await fs.writeFile(STORE_FILE, JSON.stringify([], null, 2), 'utf8');
+  }
+}
+
+/** Input for creating a new event */
+export interface CreateEventInput {
+  queryFingerprint: string;
+  label: string;
+  type: QueryEventType;
+  timestamp?: string;
+}
+
+/**
+ * List events for a given query fingerprint
+ */
+export async function listByFingerprint(fingerprint: string): Promise<QueryEvent[]> {
+  await ensureStore();
+  const items = await safeReadJson(STORE_FILE);
+  return items
+    .filter(e => e.queryFingerprint === fingerprint)
+    .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+}
+
+/**
+ * Create a new event
+ */
+export function create(input: CreateEventInput): Promise<QueryEvent> {
+  return withLock(async () => {
+    await ensureStore();
+    const items = await safeReadJson(STORE_FILE);
+
+    const newItem: QueryEvent = {
+      id: `evt_${randomUUID()}`,
+      queryFingerprint: input.queryFingerprint,
+      label: input.label,
+      type: input.type,
+      timestamp: input.timestamp || new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    };
+
+    items.push(newItem);
+    await writeAtomic(STORE_FILE, items);
+    return newItem;
+  });
+}
+
+/**
+ * Remove an event by ID
+ */
+export function remove(id: string): Promise<boolean> {
+  return withLock(async () => {
+    await ensureStore();
+    const items = await safeReadJson(STORE_FILE);
+    const index = items.findIndex(e => e.id === id);
+    if (index === -1) return false;
+    items.splice(index, 1);
+    await writeAtomic(STORE_FILE, items);
+    return true;
+  });
+}


### PR DESCRIPTION
## Summary
- SQL正規化 + SHA-256フィンガープリントで同一クエリを自動識別し、実行履歴をタイムライン表示
- イベント記録機能（インデックス追加・スキーマ変更等）でチャート上に変更ポイントをマーカー表示
- Before/After比較で既存の`computeComparisonDelta()`を再利用し、変更効果を定量化

## Changes

### Core (lib/)
- `lib/utils/query-fingerprint.ts` — SQL正規化（空白圧縮・小文字化・リテラル置換）+ SHA-256先頭16文字
- `lib/types/index.ts` — `QueryHistoryEntry`, `QueryEvent`, `QueryTimeline`等の型追加

### Web API (web/)
- `web/routes/history.ts` — 5エンドポイント: fingerprints一覧, timeline取得, before/after比較, イベントCRUD
- `web/store/events-store.ts` — イベント永続化ストア（sql-storeと同パターン）
- `web/routes/tests.ts` — テスト結果保存時にフィンガープリントを付与（後方互換あり）
- `web/server.ts` — `/api/history`ルート登録

### Frontend (web-ui/)
- `src/pages/QueryHistory.tsx` — 2カラムレイアウト（左: クエリ一覧、右: タイムライン詳細）
- `src/components/TimelineChart.tsx` — Recharts LineChart（Mean/P50/P95/P99）+ ReferenceLine（イベント）
- `src/components/EventForm.tsx` — インラインイベント追加フォーム
- `src/App.tsx` — ナビ・ルート追加
- `src/api/client.ts` — `historyApi`追加
- `src/types/index.ts` — フロントエンド型追加

### Tests
- `tests/utils/query-fingerprint.test.ts` — 15テスト（同一性・差別化・エッジケース）

## Test plan
- [x] ユニットテスト全137件パス (`npx vitest run --project unit`)
- [x] ESLint エラーなし (`cd web-ui && npm run lint`)
- [x] プロダクションビルド成功 (`cd web-ui && npm run build`)
- [x] 手動検証: 同一クエリを3回以上テスト実行 → 履歴ページでグルーピング確認
- [x] 手動検証: イベント追加 → チャートにマーカー表示確認
- [x] 手動検証: Before/After比較 → DeltaSummaryBar表示確認
- [x] 既存の結果ファイル（フィンガープリントなし）が正しく遅延計算されることを確認

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)