### PR TITLE
fix: 統計計算の標本分散修正（N → N-1）

### DIFF
--- a/lib/statistics/statistics-calculator.ts
+++ b/lib/statistics/statistics-calculator.ts
@@ -49,9 +49,10 @@ export class StatisticsCalculator {
         const min = filtered[0];
         const max = filtered[filtered.length - 1];
 
-        // Variance and standard deviation
-        const variance = filtered.reduce((s, val) =>
-            s + Math.pow(val - mean, 2), 0) / count;
+        // Variance and standard deviation (sample variance: N-1 for unbiased estimation)
+        const variance = count > 1
+            ? filtered.reduce((s, val) => s + Math.pow(val - mean, 2), 0) / (count - 1)
+            : 0;
         const stdDev = Math.sqrt(variance);
 
         // Coefficient of Variation

--- a/tests/statistics/statistics-calculator.test.ts
+++ b/tests/statistics/statistics-calculator.test.ts
@@ -79,12 +79,24 @@ describe('StatisticsCalculator', () => {
             expect(result!.count.included).toBeLessThan(result!.count.total);
         });
 
-        it('handles single-element array', () => {
+        it('calculates sample variance with N-1 (Bessel correction)', () => {
+            // [2, 4, 4, 4, 5, 5, 7, 9] — mean = 5
+            // Sum of squared deviations = 9+1+1+1+0+0+4+16 = 32
+            // Sample variance = 32 / (8-1) = 32/7 ≈ 4.571
+            const data = [2, 4, 4, 4, 5, 5, 7, 9];
+            const result = StatisticsCalculator.calculate(data, { includeDistribution: false });
+
+            expect(result!.spread.variance).toBeCloseTo(4.571, 2);
+            expect(result!.spread.stdDev).toBeCloseTo(Math.sqrt(32 / 7), 2);
+        });
+
+        it('handles single-element array (variance = 0)', () => {
             const result = StatisticsCalculator.calculate([42], { includeDistribution: false });
 
             expect(result!.basic.min).toBe(42);
             expect(result!.basic.max).toBe(42);
             expect(result!.basic.mean).toBe(42);
+            expect(result!.spread.variance).toBe(0);
             expect(result!.spread.stdDev).toBe(0);
         });
 


### PR DESCRIPTION
## Summary
- 分散計算を母分散（N）から不偏分散（N-1, Bessel's correction）に修正
- count=1 の場合のゼロ除算ガードを追加
- テストに N-1 の具体的な数値検証ケースを追加

## 変更ファイル
- `lib/statistics/statistics-calculator.ts` — 分散計算ロジック修正
- `tests/statistics/statistics-calculator.test.ts` — テスト追加・更新

## Test plan
- [x] `npm run test:unit` — 138 tests passed

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)