### PR TITLE
fix: query-fingerprint の改善（科学的記数法・HEX・衝突耐性）

### DIFF
--- a/lib/utils/query-fingerprint.ts
+++ b/lib/utils/query-fingerprint.ts
@@ -9,7 +9,7 @@
 import { createHash } from 'crypto';
 
 export interface QueryFingerprint {
-  /** SHA-256 hex, first 16 characters */
+  /** SHA-256 hex, first 32 characters (128-bit) */
   hash: string;
   /** Whitespace-collapsed, lowercased, literals-replaced SQL */
   normalized: string;
@@ -44,9 +44,10 @@ function normalizeQuery(sql: string): string {
   // Replace double-quoted string literals with ?
   s = s.replace(/"(?:[^"\\]|\\.)*"/g, '?');
 
-  // Replace numeric literals (integers and decimals) with ?
+  // Replace numeric literals with ?
+  // Handles: integers, decimals, scientific notation (1e5, 3.14e-2), hex (0xFF)
   // Negative sign is not included — it is an operator, not part of the literal
-  s = s.replace(/\b\d+(?:\.\d+)?\b/g, '?');
+  s = s.replace(/\b(?:0[xX][0-9a-fA-F]+|\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\b/g, '?');
 
   // Collapse whitespace
   s = s.replace(/\s+/g, ' ').trim();
@@ -64,10 +65,10 @@ function normalizeQuery(sql: string): string {
  * Produce a fingerprint for the given SQL text.
  *
  * @param sql - Raw SQL string (may include comments, varying whitespace, etc.)
- * @returns A fingerprint containing a 16-char hex hash and the normalized SQL
+ * @returns A fingerprint containing a 32-char hex hash (128-bit) and the normalized SQL
  */
 export function fingerprintQuery(sql: string): QueryFingerprint {
   const normalized = normalizeQuery(sql);
-  const hash = createHash('sha256').update(normalized).digest('hex').slice(0, 16);
+  const hash = createHash('sha256').update(normalized).digest('hex').slice(0, 32);
   return { hash, normalized };
 }

--- a/tests/utils/query-fingerprint.test.ts
+++ b/tests/utils/query-fingerprint.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest';
 import { fingerprintQuery } from '../../lib/utils/query-fingerprint.js';
 
 describe('fingerprintQuery', () => {
-    it('returns a 16-char hex hash', () => {
+    it('returns a 32-char hex hash (128-bit)', () => {
         const fp = fingerprintQuery('SELECT * FROM users');
-        expect(fp.hash).toMatch(/^[0-9a-f]{16}$/);
+        expect(fp.hash).toMatch(/^[0-9a-f]{32}$/);
     });
 
     it('returns normalized SQL', () => {
@@ -102,7 +102,32 @@ describe('fingerprintQuery', () => {
 
     it('handles empty-ish input gracefully', () => {
         const fp = fingerprintQuery('   ');
-        expect(fp.hash).toMatch(/^[0-9a-f]{16}$/);
+        expect(fp.hash).toMatch(/^[0-9a-f]{32}$/);
         expect(fp.normalized).toBe('');
+    });
+
+    // ── Scientific notation & hex literals ──────────────────────────────
+
+    it('normalizes scientific notation literals', () => {
+        const a = fingerprintQuery('SELECT * FROM t WHERE val > 1e5');
+        const b = fingerprintQuery('SELECT * FROM t WHERE val > 3.14e-2');
+        const c = fingerprintQuery('SELECT * FROM t WHERE val > 42');
+        expect(a.hash).toBe(b.hash);
+        expect(a.hash).toBe(c.hash);
+        expect(a.normalized).toContain('?');
+        expect(a.normalized).not.toMatch(/\d/);
+    });
+
+    it('normalizes hex literals', () => {
+        const a = fingerprintQuery('SELECT * FROM t WHERE flags = 0xFF');
+        const b = fingerprintQuery('SELECT * FROM t WHERE flags = 0x00');
+        const c = fingerprintQuery('SELECT * FROM t WHERE flags = 255');
+        expect(a.hash).toBe(b.hash);
+        expect(a.hash).toBe(c.hash);
+    });
+
+    it('normalizes mixed numeric literal types', () => {
+        const fp = fingerprintQuery('SELECT * FROM t WHERE a = 1e3 AND b = 0xAB AND c = 3.14');
+        expect(fp.normalized).toBe('select * from t where a = ? and b = ? and c = ?');
     });
 });

--- a/web/routes/history.ts
+++ b/web/routes/history.ts
@@ -130,7 +130,7 @@ router.get('/fingerprints', asyncHandler(async (_req: Request, res: Response) =>
 
 router.get('/:fingerprint', asyncHandler(async (req: Request, res: Response) => {
   const fp = req.params.fingerprint as string;
-  if (!fp || !/^[0-9a-f]{16}$/.test(fp)) {
+  if (!fp || !/^[0-9a-f]{16}(?:[0-9a-f]{16})?$/.test(fp)) {
     res.status(400).json({ success: false, error: '不正なフィンガープリントです' });
     return;
   }


### PR DESCRIPTION
## Summary
- 数値リテラルの正規表現を拡張（科学的記数法 `1e5`, `3.14e-2` / HEXリテラル `0xFF`）
- ハッシュ長を 16文字（64bit）→ 32文字（128bit）に拡張し衝突耐性を向上
- `web/routes/history.ts` のフィンガープリント検証を16文字（レガシー）と32文字の両方に対応

## 変更ファイル
- `lib/utils/query-fingerprint.ts` — 正規表現拡張 + ハッシュ長変更
- `tests/utils/query-fingerprint.test.ts` — 科学的記数法・HEX・混合リテラルのテスト追加
- `web/routes/history.ts` — バリデーション正規表現の後方互換対応

## Test plan
- [x] `npm run test:unit` — 140 tests passed

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)