### PR TITLE
refactor: lib/ と web-ui/ の型定義共有（@shared/types エイリアス）

### DIFF
--- a/web-ui/src/types/index.ts
+++ b/web-ui/src/types/index.ts
@@ -1,6 +1,21 @@
 /**
  * Shared type definitions for the MySQL Performance Tester web UI
+ *
+ * Types shared with lib/ are re-exported from @shared/types.
+ * UI-specific types (forms, state management, simplified API shapes) are defined here.
  */
+
+// Re-export shared types from lib/types (single source of truth)
+export type {
+  QueryEventType,
+  QueryEvent,
+  QueryFingerprintSummary,
+  Recommendation,
+  PerformanceGrade,
+} from '@shared/types';
+
+// Import shared types for local use in interface definitions
+import type { QueryEventType, QueryEvent } from '@shared/types';
 
 // ─── Connection ───────────────────────────────────────────────────────────
 
@@ -341,20 +356,7 @@ export interface StatCardItem {
 
 // ─── Query History ──────────────────────────────────────────────────────
 
-export type QueryEventType =
-  | 'index_added'
-  | 'index_removed'
-  | 'schema_change'
-  | 'config_change'
-  | 'custom';
-
-export interface QueryFingerprintSummary {
-  queryFingerprint: string;
-  queryText: string;
-  latestTestName: string;
-  runCount: number;
-  latestRunAt: string;
-}
+// QueryEventType, QueryEvent, QueryFingerprintSummary are re-exported from @shared/types above
 
 export interface QueryHistoryEntry {
   testId: string;
@@ -362,15 +364,6 @@ export interface QueryHistoryEntry {
   timestamp: string;
   statistics: Statistics;
   explainAccessType?: string;
-}
-
-export interface QueryEvent {
-  id: string;
-  queryFingerprint: string;
-  label: string;
-  type: QueryEventType;
-  timestamp: string;
-  createdAt: string;
 }
 
 export interface QueryTimeline {

--- a/web-ui/tsconfig.json
+++ b/web-ui/tsconfig.json
@@ -12,7 +12,10 @@
     "esModuleInterop": true,
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "paths": {
+      "@shared/types": ["../lib/types/index.ts"]
+    }
   },
-  "include": ["src"]
+  "include": ["src", "../lib/types"]
 }

--- a/web-ui/vite.config.ts
+++ b/web-ui/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@shared/types': path.resolve(__dirname, '../lib/types/index.ts'),
+    },
+  },
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
## Summary
- Vite alias `@shared/types` → `lib/types/index.ts` を追加
- 同一型（QueryEventType, QueryEvent, QueryFingerprintSummary, Recommendation, PerformanceGrade）を lib/types から re-export
- web-ui/src/types/index.ts から重複定義を削除
- UI固有型（フォーム、状態管理、簡易APIレスポンス型）はローカル維持

## Test plan
- [x] `cd web-ui && npm run lint` — Lint 通過
- [x] `cd web-ui && npm run build` — ビルド成功

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)