### PR TITLE
test: フロントエンドテスト導入（Vitest + Testing Library）

### DIFF
--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "react": "^19.2.0",
@@ -17,6 +19,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
@@ -24,7 +28,9 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "jsdom": "^29.0.1",
     "typescript": "^6.0.2",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^4.1.2"
   }
 }

--- a/web-ui/src/api/__tests__/client.test.ts
+++ b/web-ui/src/api/__tests__/client.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the API client module
+ *
+ * Uses globalThis.fetch mock to verify correct HTTP calls
+ * are made without requiring a running backend server.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { connectionsApi, sqlApi, testsApi } from '../../api/client';
+
+function mockFetchResponse(data: unknown, ok = true, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: () => Promise.resolve({ success: ok, data, error: ok ? undefined : 'Error' }),
+  });
+}
+
+describe('API client', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('connectionsApi', () => {
+    it('list() makes GET /api/connections', async () => {
+      const connections = [{ id: '1', name: 'test-db' }];
+      globalThis.fetch = mockFetchResponse(connections);
+
+      const result = await connectionsApi.list();
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        '/api/connections',
+        expect.objectContaining({ method: 'GET' }),
+      );
+      expect(result).toEqual(connections);
+    });
+
+    it('create() sends POST with body', async () => {
+      const newConn = { id: '2', name: 'new-db' };
+      globalThis.fetch = mockFetchResponse(newConn);
+
+      const body = {
+        name: 'new-db',
+        host: 'localhost',
+        port: 3306,
+        database: 'test',
+        user: 'root',
+        password: 'pass',
+        poolSize: 10,
+      };
+      const result = await connectionsApi.create(body);
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        '/api/connections',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify(body),
+        }),
+      );
+      expect(result).toEqual(newConn);
+    });
+  });
+
+  describe('sqlApi', () => {
+    it('list() with filters builds correct query params', async () => {
+      const items = [{ id: '1', name: 'select-test' }];
+      globalThis.fetch = mockFetchResponse(items);
+
+      await sqlApi.list({ category: 'performance', keyword: 'select' });
+
+      const calledUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('/api/sql?');
+      expect(calledUrl).toContain('category=performance');
+      expect(calledUrl).toContain('keyword=select');
+    });
+
+    it('list() without filters calls /api/sql without query params', async () => {
+      globalThis.fetch = mockFetchResponse([]);
+
+      await sqlApi.list();
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        '/api/sql',
+        expect.objectContaining({ method: 'GET' }),
+      );
+    });
+
+    it('list() omits empty/null/undefined filter values', async () => {
+      globalThis.fetch = mockFetchResponse([]);
+
+      await sqlApi.list({ category: '', keyword: undefined });
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        '/api/sql',
+        expect.objectContaining({ method: 'GET' }),
+      );
+    });
+  });
+
+  describe('testsApi', () => {
+    it('runSingle() sends POST /api/tests/single', async () => {
+      const response = { testId: 'abc-123' };
+      globalThis.fetch = mockFetchResponse(response);
+
+      const body = { connectionId: '1', sqlText: 'SELECT 1', testIterations: 10 };
+      const result = await testsApi.runSingle(body);
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        '/api/tests/single',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify(body),
+        }),
+      );
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws when response is not ok', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ success: false, data: null, error: 'Internal server error' }),
+      });
+
+      await expect(connectionsApi.list()).rejects.toThrow('Internal server error');
+    });
+
+    it('throws with HTTP status when no error message provided', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({ success: false, data: null }),
+      });
+
+      await expect(connectionsApi.list()).rejects.toThrow('HTTP 404');
+    });
+  });
+});

--- a/web-ui/src/components/__tests__/PercentilesTable.test.tsx
+++ b/web-ui/src/components/__tests__/PercentilesTable.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Tests for PercentilesTable component
+ *
+ * Verifies rendering of the percentiles table with
+ * correct labels and values.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PercentilesTable from '../../components/PercentilesTable';
+import type { Percentiles } from '../../types';
+
+describe('PercentilesTable', () => {
+  it('renders table with percentile rows', () => {
+    const percentiles: Percentiles = {
+      p01: 1.0,
+      p05: 2.0,
+      p10: 3.0,
+      p25: 5.0,
+      p50: 8.0,
+      p75: 12.0,
+      p90: 18.0,
+      p95: 25.0,
+      p99: 40.0,
+      p999: 55.0,
+    };
+
+    render(<PercentilesTable percentiles={percentiles} />);
+
+    // Check header
+    expect(screen.getByText('パーセンタイル')).toBeInTheDocument();
+    expect(screen.getByText('レイテンシ (ms)')).toBeInTheDocument();
+
+    // Check percentile labels are rendered
+    expect(screen.getByText('P1')).toBeInTheDocument();
+    expect(screen.getByText('P5')).toBeInTheDocument();
+    expect(screen.getByText('P10')).toBeInTheDocument();
+    expect(screen.getByText('P25')).toBeInTheDocument();
+    expect(screen.getByText('P50 (中央値)')).toBeInTheDocument();
+    expect(screen.getByText('P75')).toBeInTheDocument();
+    expect(screen.getByText('P90')).toBeInTheDocument();
+    expect(screen.getByText('P99')).toBeInTheDocument();
+    expect(screen.getByText('P99.9')).toBeInTheDocument();
+  });
+
+  it('displays correct values', () => {
+    const percentiles: Percentiles = {
+      p01: 1.5,
+      p50: 10.2,
+      p95: 25.7,
+      p99: 42.3,
+    };
+
+    render(<PercentilesTable percentiles={percentiles} />);
+
+    expect(screen.getByText('1.5')).toBeInTheDocument();
+    expect(screen.getByText('10.2')).toBeInTheDocument();
+    expect(screen.getByText('25.7')).toBeInTheDocument();
+    expect(screen.getByText('42.3')).toBeInTheDocument();
+  });
+
+  it('handles missing percentiles with dash', () => {
+    const percentiles: Percentiles = {
+      p50: 10.0,
+      // All other percentiles are undefined
+    };
+
+    render(<PercentilesTable percentiles={percentiles} />);
+
+    expect(screen.getByText('10')).toBeInTheDocument();
+
+    // Undefined values should show as '-'
+    const dashes = screen.getAllByText('-');
+    // 9 out of 10 rows should have '-' (only p50 has a value)
+    expect(dashes.length).toBe(9);
+  });
+
+  it('returns null when percentiles is undefined', () => {
+    const { container } = render(<PercentilesTable percentiles={undefined} />);
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('applies accent color to P95 row', () => {
+    const percentiles: Percentiles = {
+      p95: 20.5,
+    };
+
+    render(<PercentilesTable percentiles={percentiles} />);
+
+    const p95Value = screen.getByText('20.5');
+    expect(p95Value).toHaveStyle({ color: 'var(--color-accent)' });
+  });
+});

--- a/web-ui/src/components/__tests__/StatCardsGrid.test.tsx
+++ b/web-ui/src/components/__tests__/StatCardsGrid.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Tests for StatCardsGrid component
+ *
+ * Verifies rendering of stat cards with labels, values,
+ * units, and highlight behavior.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import StatCardsGrid from '../../components/StatCardsGrid';
+import type { StatCardItem } from '../../types';
+
+describe('StatCardsGrid', () => {
+  it('renders all stat cards with labels and values', () => {
+    const items: StatCardItem[] = [
+      { label: 'Mean', value: 12.5, unit: 'ms' },
+      { label: 'Median', value: 11.0, unit: 'ms' },
+      { label: 'P95', value: 18.3, unit: 'ms' },
+    ];
+
+    render(<StatCardsGrid items={items} />);
+
+    expect(screen.getByText('Mean')).toBeInTheDocument();
+    expect(screen.getByText('Median')).toBeInTheDocument();
+    expect(screen.getByText('P95')).toBeInTheDocument();
+    expect(screen.getByText('12.5')).toBeInTheDocument();
+    expect(screen.getByText('11')).toBeInTheDocument();
+    expect(screen.getByText('18.3')).toBeInTheDocument();
+  });
+
+  it('handles null/undefined values gracefully', () => {
+    const items: StatCardItem[] = [
+      { label: 'Mean', value: null, unit: 'ms' },
+      { label: 'Median', value: undefined, unit: 'ms' },
+      { label: 'Count', value: 0, unit: '' },
+    ];
+
+    render(<StatCardsGrid items={items} />);
+
+    // null/undefined should render as '-'
+    const dashes = screen.getAllByText('-');
+    expect(dashes).toHaveLength(2);
+
+    // 0 should still render as a value
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+
+  it('applies accent color when highlight is true', () => {
+    const items: StatCardItem[] = [
+      { label: 'Fast', value: 5.0, unit: 'ms', highlight: true },
+      { label: 'Normal', value: 10.0, unit: 'ms' },
+    ];
+
+    const { container } = render(<StatCardsGrid items={items} />);
+
+    const statValues = container.querySelectorAll('.stat-value');
+    // First card has highlight
+    expect(statValues[0]).toHaveStyle({ color: 'var(--color-accent)' });
+    // Second card does not
+    expect(statValues[1]).not.toHaveStyle({ color: 'var(--color-accent)' });
+  });
+
+  it('renders string values', () => {
+    const items: StatCardItem[] = [
+      { label: 'Status', value: 'OK', unit: '' },
+    ];
+
+    render(<StatCardsGrid items={items} />);
+
+    expect(screen.getByText('OK')).toBeInTheDocument();
+  });
+
+  it('uses specified column count', () => {
+    const items: StatCardItem[] = [
+      { label: 'A', value: 1, unit: '' },
+    ];
+
+    const { container } = render(<StatCardsGrid items={items} columns={3} />);
+
+    const grid = container.querySelector('.card-grid');
+    expect(grid).toHaveClass('card-grid-3');
+  });
+});

--- a/web-ui/src/hooks/__tests__/useTestExecution.test.ts
+++ b/web-ui/src/hooks/__tests__/useTestExecution.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for useTestExecution hook reducer logic
+ *
+ * We test the reducer indirectly through the hook using renderHook.
+ * The hook wraps a useReducer with runReducer, so dispatching actions
+ * lets us verify all state transitions.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import useTestExecution from '../../hooks/useTestExecution';
+import type { RunState, WsMessage } from '../../types';
+
+const EMPTY_WS: WsMessage[] = [];
+
+function getInitialState(): RunState {
+  return {
+    runState: null,
+    progress: { phase: '', current: 0, total: 0, duration: null },
+    liveData: [],
+    result: null,
+    results: null,
+    comparison: null,
+    errorMsg: '',
+  };
+}
+
+describe('useTestExecution', () => {
+  it('returns initial state', () => {
+    const { result } = renderHook(() => useTestExecution(EMPTY_WS));
+    expect(result.current.run).toEqual(getInitialState());
+    expect(result.current.currentTestId).toBeNull();
+  });
+
+  it('"start" action sets runState to running', () => {
+    const { result } = renderHook(() => useTestExecution(EMPTY_WS));
+
+    act(() => {
+      result.current.dispatch({
+        type: 'start',
+        progress: { phase: 'warmup', current: 0, total: 100, duration: null },
+      });
+    });
+
+    expect(result.current.run.runState).toBe('running');
+    expect(result.current.run.progress.phase).toBe('warmup');
+    expect(result.current.run.progress.total).toBe(100);
+  });
+
+  it('"progress" action updates progress and liveData', () => {
+    const { result } = renderHook(() => useTestExecution(EMPTY_WS));
+
+    act(() => {
+      result.current.dispatch({
+        type: 'start',
+        progress: { phase: 'testing', current: 0, total: 10, duration: null },
+      });
+    });
+
+    act(() => {
+      result.current.dispatch({
+        type: 'progress',
+        data: { phase: 'testing', current: 1, total: 10, duration: 5.2 },
+      });
+    });
+
+    expect(result.current.run.progress.current).toBe(1);
+    expect(result.current.run.progress.duration).toBe(5.2);
+    expect(result.current.run.liveData).toHaveLength(1);
+    expect(result.current.run.liveData[0]).toEqual({ t: 0, duration: 5.2 });
+  });
+
+  it('"complete" action with single test result', () => {
+    const { result } = renderHook(() => useTestExecution(EMPTY_WS));
+
+    act(() => {
+      result.current.dispatch({
+        type: 'start',
+        progress: { phase: 'testing', current: 0, total: 10, duration: null },
+      });
+    });
+
+    const singleResult = {
+      statistics: { basic: { mean: 12.5, median: 11.0 } },
+    };
+
+    act(() => {
+      result.current.dispatch({
+        type: 'complete',
+        data: { result: singleResult },
+      });
+    });
+
+    expect(result.current.run.runState).toBe('complete');
+    expect(result.current.run.result).toEqual(singleResult);
+    expect(result.current.run.results).toBeNull();
+    expect(result.current.run.comparison).toBeNull();
+  });
+
+  it('"complete" action with parallel results', () => {
+    const { result } = renderHook(() => useTestExecution(EMPTY_WS));
+
+    act(() => {
+      result.current.dispatch({
+        type: 'start',
+        progress: { phase: 'testing', current: 0, total: 10, duration: null },
+      });
+    });
+
+    const parallelResults = {
+      'round-robin': {
+        metrics: { queries: { total: 100, successRate: '100%' } },
+      },
+    };
+
+    act(() => {
+      result.current.dispatch({
+        type: 'complete',
+        data: { results: parallelResults },
+      });
+    });
+
+    expect(result.current.run.runState).toBe('complete');
+    expect(result.current.run.results).toEqual(parallelResults);
+    expect(result.current.run.result).toBeNull();
+  });
+
+  it('"complete" action with comparison results', () => {
+    const { result } = renderHook(() => useTestExecution(EMPTY_WS));
+
+    act(() => {
+      result.current.dispatch({
+        type: 'start',
+        progress: { phase: 'testing', current: 0, total: 10, duration: null },
+      });
+    });
+
+    const comparison = {
+      resultA: { statistics: { basic: { mean: 10 } } },
+      resultB: { statistics: { basic: { mean: 15 } } },
+      delta: null,
+      executionMode: 'sequential' as const,
+      testNameA: 'Query A',
+      testNameB: 'Query B',
+    };
+
+    act(() => {
+      result.current.dispatch({
+        type: 'complete',
+        data: { comparison },
+      });
+    });
+
+    expect(result.current.run.runState).toBe('complete');
+    expect(result.current.run.comparison).toEqual(comparison);
+    expect(result.current.run.result).toBeNull();
+    expect(result.current.run.results).toBeNull();
+  });
+
+  it('"error" action sets errorMsg', () => {
+    const { result } = renderHook(() => useTestExecution(EMPTY_WS));
+
+    act(() => {
+      result.current.dispatch({
+        type: 'start',
+        progress: { phase: 'testing', current: 0, total: 10, duration: null },
+      });
+    });
+
+    act(() => {
+      result.current.dispatch({
+        type: 'error',
+        data: { message: 'Connection refused' },
+      });
+    });
+
+    expect(result.current.run.runState).toBe('error');
+    expect(result.current.run.errorMsg).toBe('Connection refused');
+  });
+
+  it('liveData is capped at 61 items (keeps last 60 + adds 1)', () => {
+    const { result } = renderHook(() => useTestExecution(EMPTY_WS));
+
+    act(() => {
+      result.current.dispatch({
+        type: 'start',
+        progress: { phase: 'testing', current: 0, total: 200, duration: null },
+      });
+    });
+
+    // Dispatch 70 progress updates
+    for (let i = 0; i < 70; i++) {
+      act(() => {
+        result.current.dispatch({
+          type: 'progress',
+          data: { phase: 'testing', current: i, total: 200, duration: i * 1.0 },
+        });
+      });
+    }
+
+    // The slice(-60) keeps the last 60 items from previous state,
+    // then adds 1 new item, so max length is 61
+    expect(result.current.run.liveData.length).toBeLessThanOrEqual(61);
+    expect(result.current.run.liveData.length).toBeGreaterThan(0);
+  });
+
+  it('"start" resets state to initial values', () => {
+    const { result } = renderHook(() => useTestExecution(EMPTY_WS));
+
+    // First run an error
+    act(() => {
+      result.current.dispatch({
+        type: 'error',
+        data: { message: 'Some error' },
+      });
+    });
+
+    // Then start a new run
+    act(() => {
+      result.current.dispatch({
+        type: 'start',
+        progress: { phase: 'warmup', current: 0, total: 50, duration: null },
+      });
+    });
+
+    expect(result.current.run.runState).toBe('running');
+    expect(result.current.run.errorMsg).toBe('');
+    expect(result.current.run.result).toBeNull();
+    expect(result.current.run.liveData).toEqual([]);
+  });
+});

--- a/web-ui/src/test-setup.ts
+++ b/web-ui/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/web-ui/vitest.config.ts
+++ b/web-ui/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@shared/types': path.resolve(__dirname, '../lib/types/index.ts'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test-setup.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
+});


### PR DESCRIPTION
## Summary
web-ui/ にフロントエンドテスト基盤を導入。

### テスト基盤
- vitest + @testing-library/react + @testing-library/jest-dom + jsdom
- web-ui/vitest.config.ts（jsdom 環境、@shared/types alias）
- test / test:watch npm scripts

### テストファイル（27テスト）
| ファイル | テスト数 | 対象 |
|---------|---------|------|
| src/hooks/__tests__/useTestExecution.test.ts | 8 | Reducer ロジック（start/progress/complete/error） |
| src/api/__tests__/client.test.ts | 8 | API クライアント（fetch mock） |
| src/components/__tests__/StatCardsGrid.test.tsx | 5 | StatCards レンダリング |
| src/components/__tests__/PercentilesTable.test.tsx | 6 | パーセンタイルテーブル |

## Test plan
- [x] `cd web-ui && npx vitest run` — 27 tests passed

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)