### PR TITLE
feat: WebSocket ワンタイムトークン認証

### DIFF
--- a/web-ui/src/hooks/useWebSocket.ts
+++ b/web-ui/src/hooks/useWebSocket.ts
@@ -28,11 +28,29 @@ export function useWebSocket(onMessage: WsMessageHandler): {
   const pendingSubscribesRef = useRef<Set<string>>(new Set());
   const connectRef = useRef<(() => void) | null>(null);
 
-  const connect = useCallback(() => {
+  const connect = useCallback(async () => {
     if (!mountedRef.current) return;
 
     try {
-      const ws = new WebSocket(WS_URL);
+      // Fetch a one-time authentication token before opening the WebSocket
+      let wsUrl = WS_URL;
+      try {
+        const res = await fetch('/api/ws-token');
+        if (res.ok) {
+          const data = (await res.json()) as { success: boolean; token: string };
+          if (data.success && data.token) {
+            const separator = WS_URL.includes('?') ? '&' : '?';
+            wsUrl = `${WS_URL}${separator}token=${data.token}`;
+          }
+        }
+      } catch {
+        // Token fetch failed — attempt connection without token (localhost dev fallback)
+        console.warn('[WS] Failed to fetch auth token, connecting without token');
+      }
+
+      if (!mountedRef.current) return;
+
+      const ws = new WebSocket(wsUrl);
       wsRef.current = ws;
 
       ws.onopen = () => {
@@ -61,7 +79,7 @@ export function useWebSocket(onMessage: WsMessageHandler): {
         );
         retryCountRef.current += 1;
         console.log(`[WS] Disconnected. Reconnecting in ${delay}ms...`);
-        reconnectTimerRef.current = setTimeout(() => connectRef.current?.(), delay);
+        reconnectTimerRef.current = setTimeout(() => { void connectRef.current?.(); }, delay);
       };
 
       ws.onerror = () => {
@@ -76,7 +94,7 @@ export function useWebSocket(onMessage: WsMessageHandler): {
 
   useEffect(() => {
     mountedRef.current = true;
-    connect();
+    void connect();
     return () => {
       mountedRef.current = false;
       if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);

--- a/web/security/ws-token.ts
+++ b/web/security/ws-token.ts
@@ -1,0 +1,57 @@
+/**
+ * ws-token.ts - One-time WebSocket authentication token manager
+ *
+ * Generates short-lived tokens that the frontend fetches via REST API
+ * and passes as a query parameter when opening a WebSocket connection.
+ * Each token is single-use: validate() consumes it immediately.
+ */
+
+import crypto from 'crypto';
+
+const DEFAULT_TTL_MS = 60_000;
+const CLEANUP_INTERVAL_MS = 60_000;
+
+interface TokenEntry {
+  expiresAt: number;
+}
+
+class WsTokenManager {
+  private tokens = new Map<string, TokenEntry>();
+  private cleanupTimer: ReturnType<typeof setInterval>;
+
+  constructor() {
+    this.cleanupTimer = setInterval(() => this.cleanup(), CLEANUP_INTERVAL_MS);
+    this.cleanupTimer.unref(); // Don't keep process alive
+  }
+
+  /** Generate a one-time token with the given TTL (default 60 s). */
+  generate(ttlMs = DEFAULT_TTL_MS): string {
+    const token = crypto.randomUUID();
+    this.tokens.set(token, { expiresAt: Date.now() + ttlMs });
+    return token;
+  }
+
+  /** Validate and consume a token. Returns true if valid; the token is deleted regardless. */
+  validate(token: string): boolean {
+    const entry = this.tokens.get(token);
+    if (!entry) return false;
+    this.tokens.delete(token); // One-time use
+    return Date.now() < entry.expiresAt;
+  }
+
+  /** Remove all expired tokens. */
+  private cleanup(): void {
+    const now = Date.now();
+    for (const [token, entry] of this.tokens) {
+      if (now >= entry.expiresAt) this.tokens.delete(token);
+    }
+  }
+
+  /** Tear down the cleanup timer and clear all tokens. */
+  destroy(): void {
+    clearInterval(this.cleanupTimer);
+    this.tokens.clear();
+  }
+}
+
+export const wsTokenManager = new WsTokenManager();

--- a/web/server.ts
+++ b/web/server.ts
@@ -33,6 +33,7 @@ import testsRouter from './routes/tests.js';
 import reportsRouter from './routes/reports.js';
 import historyRouter from './routes/history.js';
 import { errorHandler } from './middleware/error-handler.js';
+import { wsTokenManager } from './security/ws-token.js';
 
 /** Extended WebSocket with subscription management */
 interface SubscribableWebSocket extends WsWebSocket {
@@ -108,13 +109,24 @@ const LOCALHOST_ADDRS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
 wss.on('connection', (ws: SubscribableWebSocket, req) => {
   const clientIp = req.socket.remoteAddress;
 
-  // TODO: Implement token-based authentication for remote access
-  //   e.g., ws://host:port?token=xxx -> validate token from req.url
-  // Reject WebSocket connections from non-localhost
-  if (!LOCALHOST_ADDRS.has(clientIp ?? '')) {
-    console.warn(`[WS] Rejected non-localhost connection from: ${clientIp}`);
-    ws.close(1008, 'Forbidden');
-    return;
+  // Token-based authentication for WebSocket connections
+  const url = new URL(req.url || '', 'http://localhost');
+  const token = url.searchParams.get('token');
+
+  if (token) {
+    // Validate one-time token (works for both local and remote clients)
+    if (!wsTokenManager.validate(token)) {
+      console.warn(`[WS] Rejected connection with invalid/expired token from: ${clientIp}`);
+      ws.close(4001, 'Invalid or expired token');
+      return;
+    }
+  } else {
+    // Fallback: allow localhost without token (development convenience)
+    if (!LOCALHOST_ADDRS.has(clientIp ?? '')) {
+      console.warn(`[WS] Rejected non-localhost connection without token from: ${clientIp}`);
+      ws.close(4001, 'Invalid or expired token');
+      return;
+    }
   }
 
   console.log(`[WS] Client connected: ${clientIp}`);
@@ -159,6 +171,12 @@ app.use('/api/tests', testRateLimit, testsRouter);
 app.use('/api/reports', reportsRouter);
 app.use('/api/history', historyRouter);
 
+// ─── WebSocket token endpoint ────────────────────────────────────────────
+app.get('/api/ws-token', (_req: Request, res: Response) => {
+  const token = wsTokenManager.generate();
+  res.json({ success: true, token });
+});
+
 // ─── Health check ────────────────────────────────────────────────────────
 app.get('/api/health', (_req: Request, res: Response) => {
   res.json({
@@ -182,6 +200,9 @@ httpServer.listen(PORT, () => {
 // ─── Graceful Shutdown ──────────────────────────────────────────────────
 function gracefulShutdown(signal: string): void {
   console.log(`\n[Server] ${signal} received. Shutting down gracefully...`);
+
+  // Clean up token manager
+  wsTokenManager.destroy();
 
   // Reject new WebSocket connections and close existing clients
   wss.clients.forEach(client => client.close(1001, 'Server shutting down'));


### PR DESCRIPTION
## Summary
WebSocket 接続にワンタイムトークン認証を追加。

### フロー
1. クライアントが `GET /api/ws-token` でトークンを取得
2. `ws://host:port?token=xxx` で WebSocket 接続
3. サーバーがトークンを検証（1回限り使用、60秒有効）
4. 不正トークンは code 4001 で接続拒否

### 変更ファイル
- `web/security/ws-token.ts`（新規）— トークン生成・検証・有効期限管理
- `web/server.ts` — `/api/ws-token` エンドポイント追加、WebSocket ハンドラ更新
- `web-ui/src/hooks/useWebSocket.ts` — 接続前にトークン取得、フォールバック対応

### セキュリティ
- UUID v4 によるランダムトークン生成
- 60秒 TTL + ワンタイム消費（リプレイ攻撃防止）
- localhost 接続はトークンなしでも許可（開発用フォールバック）

## Test plan
- [x] `npm run test:unit` — 361 tests passed
- [x] web/ と lib/ の型チェック通過

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)