### PR TITLE
fix: resolve 50 TypeScript errors in test files

### DIFF
--- a/lib/parallel/distribution-strategy.ts
+++ b/lib/parallel/distribution-strategy.ts
@@ -34,7 +34,7 @@ export class DistributionStrategy {
  * Random distribution strategy
  */
 export class RandomDistributionStrategy extends DistributionStrategy {
-    selectSQLFile(_threadId: number, _iteration: number): SQLFile | null {
+    selectSQLFile(_threadId: number, _iteration: number, _testIterations: number): SQLFile | null {
         return this.sqlFileManager.getRandomSQLFile();
     }
 }
@@ -63,7 +63,7 @@ export class SequentialDistributionStrategy extends DistributionStrategy {
         this.currentIndex = 0;
     }
 
-    selectSQLFile(_threadId: number, _iteration: number): SQLFile | null {
+    selectSQLFile(_threadId: number, _iteration: number, _testIterations: number): SQLFile | null {
         const fileCount = this.sqlFileManager.getFileCount();
         if (fileCount === 0) return null;
 
@@ -77,7 +77,7 @@ export class SequentialDistributionStrategy extends DistributionStrategy {
  * Category-based distribution strategy
  */
 export class CategoryBasedDistributionStrategy extends DistributionStrategy {
-    selectSQLFile(threadId: number, _iteration: number): SQLFile | null {
+    selectSQLFile(threadId: number, _iteration: number, _testIterations: number): SQLFile | null {
         const files = this.sqlFileManager.getSQLFiles();
         if (files.length === 0) return null;
 

--- a/tests/config/test-configuration.test.ts
+++ b/tests/config/test-configuration.test.ts
@@ -157,7 +157,7 @@ describe('validateTestConfig', () => {
 
   it('should reject invalid outlierMethod', () => {
     const config = createTestConfig();
-    (config as Record<string, unknown>).outlierMethod = 'invalid';
+    (config as unknown as Record<string, unknown>).outlierMethod = 'invalid';
     const result = validateTestConfig(config);
     expect(result.valid).toBe(false);
     expect(result.errors).toContain('outlierMethod must be one of: iqr, zscore, mad');

--- a/tests/store/connections-store.test.ts
+++ b/tests/store/connections-store.test.ts
@@ -65,7 +65,7 @@ describe('connections-store', () => {
       expect(result[0].passwordMasked).toBe('••••••••');
       expect(result[1].passwordMasked).toBe('••••••••');
       // Should not have the password field
-      expect((result[0] as Record<string, unknown>).password).toBeUndefined();
+      expect((result[0] as unknown as Record<string, unknown>).password).toBeUndefined();
     });
   });
 

--- a/tests/store/events-store.test.ts
+++ b/tests/store/events-store.test.ts
@@ -48,7 +48,7 @@ describe('events-store', () => {
 
     it('should return events for the given fingerprint only', async () => {
       await store.create({ queryFingerprint: 'fp_A', label: 'Event A1', type: 'index_added' });
-      await store.create({ queryFingerprint: 'fp_B', label: 'Event B1', type: 'config_changed' });
+      await store.create({ queryFingerprint: 'fp_B', label: 'Event B1', type: 'config_change' });
       await store.create({ queryFingerprint: 'fp_A', label: 'Event A2', type: 'index_removed' });
 
       const result = await store.listByFingerprint('fp_A');


### PR DESCRIPTION
## Summary
- Align subclass `selectSQLFile` signatures with base class contract (3 params)
- Fix `RecommendationEngine` test helper to use proper type assertion via `ConstructorParameters`
- Add double cast (`as unknown as Record<string, unknown>`) in test-configuration and connections-store tests
- Fix typo: `"config_changed"` → `"config_change"` in events-store test

Closes #38

## Verification
- `npm run typecheck` — 0 errors (was 50)
- `npm run test:unit` — 410 tests passed

## Test plan
- [x] `npm run typecheck` passes with zero errors
- [x] `npm run test:unit` all 410 tests pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)