### PR TITLE
fix: bind server to localhost by default + configurable CORS origin

### DIFF
--- a/web/server.ts
+++ b/web/server.ts
@@ -75,8 +75,11 @@ app.use(helmet({
   }
 }));
 
+const corsOrigins = process.env.CORS_ORIGIN
+  ? process.env.CORS_ORIGIN.split(',').map(s => s.trim())
+  : ['http://localhost:5173', 'http://127.0.0.1:5173'];
 app.use(cors({
-  origin: ['http://localhost:5173', 'http://127.0.0.1:5173'],
+  origin: corsOrigins,
   credentials: true
 }));
 app.use(express.json({ limit: '10mb' }));
@@ -194,11 +197,12 @@ app.get('/api/health', (_req: Request, res: Response) => {
 app.use(errorHandler);
 
 // ─── Start ───────────────────────────────────────────────────────────────
-httpServer.listen(PORT, () => {
+const BIND_HOST = process.env.BIND_HOST || '127.0.0.1';
+httpServer.listen(Number(PORT), BIND_HOST, () => {
   console.log(`\n🚀 MySQL Performance Tester Web API`);
-  console.log(`   REST API : http://localhost:${PORT}/api`);
-  console.log(`   WebSocket: ws://localhost:${PORT}`);
-  console.log(`   Health   : http://localhost:${PORT}/api/health\n`);
+  console.log(`   REST API : http://${BIND_HOST}:${PORT}/api`);
+  console.log(`   WebSocket: ws://${BIND_HOST}:${PORT}`);
+  console.log(`   Health   : http://${BIND_HOST}:${PORT}/api/health\n`);
 });
 
 // ─── Graceful Shutdown ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Default bind address changed from `0.0.0.0` to `127.0.0.1` (security)
- Add `BIND_HOST` env var to override bind address when needed
- Add `CORS_ORIGIN` env var for configurable CORS origins (comma-separated)

Closes #39

## Test plan
- [x] Server starts on `127.0.0.1:3001` by default
- [x] `BIND_HOST=0.0.0.0` overrides to listen on all interfaces
- [x] `CORS_ORIGIN=http://localhost:5173,http://example.com` works with multiple origins
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)