### PR TITLE
refactor: extract shared round()/calculatePercentile() to math-utils

### DIFF
--- a/lib/statistics/distribution-analyzer.ts
+++ b/lib/statistics/distribution-analyzer.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Distribution, DistributionBin } from '../types/index.js';
+import { round } from './math-utils.js';
 
 export class DistributionAnalyzer {
     /**
@@ -38,29 +39,16 @@ export class DistributionAnalyzer {
         });
 
         bins.forEach(bin => {
-            bin.percentage = this.round((bin.count / sortedArray.length) * 100, 2)!;
-            bin.start = this.round(bin.start, 3)!;
-            bin.end = this.round(bin.end, 3)!;
+            bin.percentage = round((bin.count / sortedArray.length) * 100, 2)!;
+            bin.start = round(bin.start, 3)!;
+            bin.end = round(bin.end, 3)!;
         });
 
         return {
             bins,
             binCount,
-            binWidth: this.round(binWidth, 3)!
+            binWidth: round(binWidth, 3)!
         };
     }
 
-    /**
-     * Round a number to the specified decimal places
-     * @param value - The value to round
-     * @param decimals - Number of decimal places
-     * @returns The rounded value
-     */
-    static round(value: number, decimals: number): number | null {
-        if (value === null || value === undefined || isNaN(value)) {
-            return null;
-        }
-        const multiplier = Math.pow(10, decimals);
-        return Math.round(value * multiplier) / multiplier;
-    }
 }

--- a/lib/statistics/index.ts
+++ b/lib/statistics/index.ts
@@ -6,3 +6,4 @@
 export { StatisticsCalculator } from './statistics-calculator.js';
 export { OutlierDetector } from './outlier-detector.js';
 export { DistributionAnalyzer } from './distribution-analyzer.js';
+export { round, calculatePercentile } from './math-utils.js';

--- a/lib/statistics/math-utils.ts
+++ b/lib/statistics/math-utils.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared math utility functions for statistics and analysis modules
+ */
+
+/**
+ * Round a number to the specified decimal places
+ * @param value - The value to round
+ * @param decimals - Number of decimal places
+ * @returns The rounded value, or null for NaN/null/undefined inputs
+ */
+export function round(value: number, decimals: number): number | null {
+    if (value === null || value === undefined || isNaN(value)) {
+        return null;
+    }
+    const multiplier = Math.pow(10, decimals);
+    return Math.round(value * multiplier) / multiplier;
+}
+
+/**
+ * Calculate a percentile from a pre-sorted numeric array using linear interpolation
+ * @param sortedArray - Pre-sorted numeric array
+ * @param percentile - Percentile value (0-100)
+ * @returns The percentile value, or null for empty arrays
+ */
+export function calculatePercentile(sortedArray: number[], percentile: number): number | null {
+    if (percentile < 0 || percentile > 100) {
+        throw new Error('Percentile must be between 0 and 100');
+    }
+
+    if (sortedArray.length === 0) {
+        return null;
+    }
+
+    if (sortedArray.length === 1) {
+        return sortedArray[0];
+    }
+
+    const index = (percentile / 100) * (sortedArray.length - 1);
+    const lower = Math.floor(index);
+    const upper = Math.ceil(index);
+    const weight = index - lower;
+
+    if (lower === upper) {
+        return sortedArray[lower];
+    }
+
+    // Linear interpolation
+    return sortedArray[lower] * (1 - weight) + sortedArray[upper] * weight;
+}

--- a/lib/statistics/outlier-detector.ts
+++ b/lib/statistics/outlier-detector.ts
@@ -3,6 +3,8 @@
  * Detects and removes outliers using multiple statistical methods
  */
 
+import { round, calculatePercentile } from './math-utils.js';
+
 interface OutlierResult {
     filtered: number[];
     outliers: number[];
@@ -41,8 +43,8 @@ export class OutlierDetector {
      * @returns Filtered data with outlier information and bounds
      */
     static removeOutliersIQR(sortedArray: number[], multiplier: number = 1.5): OutlierResult {
-        const q1 = this.calculatePercentile(sortedArray, 25);
-        const q3 = this.calculatePercentile(sortedArray, 75);
+        const q1 = calculatePercentile(sortedArray, 25);
+        const q3 = calculatePercentile(sortedArray, 75);
         const iqr = q3! - q1!;
 
         const lowerBound = q1! - multiplier * iqr;
@@ -63,8 +65,8 @@ export class OutlierDetector {
             filtered,
             outliers,
             bounds: {
-                lower: this.round(lowerBound, 3),
-                upper: this.round(upperBound, 3)
+                lower: round(lowerBound, 3),
+                upper: round(upperBound, 3)
             }
         };
     }
@@ -104,9 +106,9 @@ export class OutlierDetector {
      * @returns Filtered data with outlier information
      */
     static removeOutliersMAD(sortedArray: number[], threshold: number = 3.5): OutlierResult {
-        const median = this.calculatePercentile(sortedArray, 50)!;
+        const median = calculatePercentile(sortedArray, 50)!;
         const deviations = sortedArray.map(val => Math.abs(val - median));
-        const madValue = this.calculatePercentile(deviations.sort((a, b) => a - b), 50)!;
+        const madValue = calculatePercentile(deviations.sort((a, b) => a - b), 50)!;
 
         // Modified Z-score = 0.6745 * (x - median) / MAD
         const filtered: number[] = [];
@@ -124,49 +126,4 @@ export class OutlierDetector {
         return { filtered, outliers };
     }
 
-    /**
-     * Calculate percentile using linear interpolation
-     * @param sortedArray - Pre-sorted numeric array
-     * @param percentile - Percentile value (0-100)
-     * @returns The percentile value
-     */
-    static calculatePercentile(sortedArray: number[], percentile: number): number | null {
-        if (percentile < 0 || percentile > 100) {
-            throw new Error('Percentile must be between 0 and 100');
-        }
-
-        if (sortedArray.length === 0) {
-            return null;
-        }
-
-        if (sortedArray.length === 1) {
-            return sortedArray[0];
-        }
-
-        const index = (percentile / 100) * (sortedArray.length - 1);
-        const lower = Math.floor(index);
-        const upper = Math.ceil(index);
-        const weight = index - lower;
-
-        if (lower === upper) {
-            return sortedArray[lower];
-        }
-
-        // Linear interpolation
-        return sortedArray[lower] * (1 - weight) + sortedArray[upper] * weight;
-    }
-
-    /**
-     * Round a number to the specified decimal places
-     * @param value - The value to round
-     * @param decimals - Number of decimal places
-     * @returns The rounded value
-     */
-    static round(value: number, decimals: number): number | null {
-        if (value === null || value === undefined || isNaN(value)) {
-            return null;
-        }
-        const multiplier = Math.pow(10, decimals);
-        return Math.round(value * multiplier) / multiplier;
-    }
 }

--- a/lib/statistics/statistics-calculator.ts
+++ b/lib/statistics/statistics-calculator.ts
@@ -5,6 +5,7 @@
 
 import { OutlierDetector } from './outlier-detector.js';
 import { DistributionAnalyzer } from './distribution-analyzer.js';
+import { round, calculatePercentile } from './math-utils.js';
 import type { Percentiles, StatisticsResult } from '../types/index.js';
 
 interface CalculateOptions {
@@ -60,16 +61,16 @@ export class StatisticsCalculator {
 
         // Percentiles
         const percentiles: Percentiles = {
-            p01: this.calculatePercentile(filtered, 1)!,
-            p05: this.calculatePercentile(filtered, 5)!,
-            p10: this.calculatePercentile(filtered, 10)!,
-            p25: this.calculatePercentile(filtered, 25)!,
-            p50: this.calculatePercentile(filtered, 50)!, // median
-            p75: this.calculatePercentile(filtered, 75)!,
-            p90: this.calculatePercentile(filtered, 90)!,
-            p95: this.calculatePercentile(filtered, 95)!,
-            p99: this.calculatePercentile(filtered, 99)!,
-            p999: this.calculatePercentile(filtered, 99.9)!
+            p01: calculatePercentile(filtered, 1)!,
+            p05: calculatePercentile(filtered, 5)!,
+            p10: calculatePercentile(filtered, 10)!,
+            p25: calculatePercentile(filtered, 25)!,
+            p50: calculatePercentile(filtered, 50)!, // median
+            p75: calculatePercentile(filtered, 75)!,
+            p90: calculatePercentile(filtered, 90)!,
+            p95: calculatePercentile(filtered, 95)!,
+            p99: calculatePercentile(filtered, 99)!,
+            p999: calculatePercentile(filtered, 99.9)!
         };
 
         const result: StatisticsResult = {
@@ -79,28 +80,28 @@ export class StatisticsCalculator {
                 outliers: outliers.length
             },
             basic: {
-                min: this.round(min, 3)!,
-                max: this.round(max, 3)!,
-                mean: this.round(mean, 3)!,
-                median: this.round(percentiles.p50, 3)!,
-                sum: this.round(sum, 3)!
+                min: round(min, 3)!,
+                max: round(max, 3)!,
+                mean: round(mean, 3)!,
+                median: round(percentiles.p50, 3)!,
+                sum: round(sum, 3)!
             },
             spread: {
-                range: this.round(max - min, 3)!,
-                variance: this.round(variance, 3)!,
-                stdDev: this.round(stdDev, 3)!,
-                cv: this.round(cv, 2)!, // %
-                iqr: this.round(percentiles.p75 - percentiles.p25, 3)!
+                range: round(max - min, 3)!,
+                variance: round(variance, 3)!,
+                stdDev: round(stdDev, 3)!,
+                cv: round(cv, 2)!, // %
+                iqr: round(percentiles.p75 - percentiles.p25, 3)!
             },
             percentiles: Object.fromEntries(
                 Object.entries(percentiles).map(([key, val]) =>
-                    [key, this.round(val, 3)!]
+                    [key, round(val, 3)!]
                 )
             ) as unknown as Percentiles,
             outliers: removeOutliers ? {
                 count: outliers.length,
-                percentage: this.round((outliers.length / durations.length) * 100, 2)!,
-                values: outliers.map(v => this.round(v, 3)!),
+                percentage: round((outliers.length / durations.length) * 100, 2)!,
+                values: outliers.map(v => round(v, 3)!),
                 method: outlierMethod
             } : null
         };
@@ -113,49 +114,4 @@ export class StatisticsCalculator {
         return result;
     }
 
-    /**
-     * Calculate percentile using linear interpolation
-     * @param sortedArray - Pre-sorted numeric array
-     * @param percentile - Percentile value (0-100)
-     * @returns The percentile value
-     */
-    static calculatePercentile(sortedArray: number[], percentile: number): number | null {
-        if (percentile < 0 || percentile > 100) {
-            throw new Error('Percentile must be between 0 and 100');
-        }
-
-        if (sortedArray.length === 0) {
-            return null;
-        }
-
-        if (sortedArray.length === 1) {
-            return sortedArray[0];
-        }
-
-        const index = (percentile / 100) * (sortedArray.length - 1);
-        const lower = Math.floor(index);
-        const upper = Math.ceil(index);
-        const weight = index - lower;
-
-        if (lower === upper) {
-            return sortedArray[lower];
-        }
-
-        // Linear interpolation
-        return sortedArray[lower] * (1 - weight) + sortedArray[upper] * weight;
-    }
-
-    /**
-     * Round a number to the specified decimal places
-     * @param value - The value to round
-     * @param decimals - Number of decimal places
-     * @returns The rounded value
-     */
-    static round(value: number, decimals: number): number | null {
-        if (value === null || value === undefined || isNaN(value)) {
-            return null;
-        }
-        const multiplier = Math.pow(10, decimals);
-        return Math.round(value * multiplier) / multiplier;
-    }
 }

--- a/lib/warmup/cache-effectiveness-analyzer.ts
+++ b/lib/warmup/cache-effectiveness-analyzer.ts
@@ -3,6 +3,8 @@
  * Analyzes cache effectiveness from warmup execution results.
  */
 
+import { round } from '../statistics/math-utils.js';
+
 /** Result of a single warmup iteration */
 export interface WarmupIterationResult {
     iteration: number;
@@ -60,9 +62,9 @@ export class CacheEffectivenessAnalyzer {
         const trend = this.analyzeTrend(durations);
 
         return {
-            firstHalfAvg: this.round(avgFirst, 2),
-            secondHalfAvg: this.round(avgSecond, 2),
-            improvementPercentage: this.round(improvement, 2),
+            firstHalfAvg: round(avgFirst, 2),
+            secondHalfAvg: round(avgSecond, 2),
+            improvementPercentage: round(improvement, 2),
             effectivenessRating: this.rateEffectiveness(improvement),
             trend: trend,
             recommendation: this.generateRecommendation(improvement, trend)
@@ -101,9 +103,9 @@ export class CacheEffectivenessAnalyzer {
 
         return {
             type: trendType,
-            group1Avg: this.round(avg1, 2),
-            group2Avg: this.round(avg2, 2),
-            group3Avg: this.round(avg3, 2)
+            group1Avg: round(avg1, 2),
+            group2Avg: round(avg2, 2),
+            group3Avg: round(avg3, 2)
         };
     }
 
@@ -146,17 +148,4 @@ export class CacheEffectivenessAnalyzer {
         }
     }
 
-    /**
-     * Round a number to the specified decimal places.
-     * @param value - Value to round
-     * @param decimals - Number of decimal places
-     * @returns Rounded value, or null if input is invalid
-     */
-    static round(value: number, decimals: number): number | null {
-        if (value === null || value === undefined || isNaN(value)) {
-            return null;
-        }
-        const multiplier = Math.pow(10, decimals);
-        return Math.round(value * multiplier) / multiplier;
-    }
 }

--- a/lib/warmup/warmup-manager.ts
+++ b/lib/warmup/warmup-manager.ts
@@ -8,6 +8,7 @@ import {
     type WarmupIterationResult,
     type CacheEffectivenessResult
 } from './cache-effectiveness-analyzer.js';
+import { round } from '../statistics/math-utils.js';
 
 /** Configuration for warmup behavior */
 export interface WarmupConfig {
@@ -121,8 +122,8 @@ export class WarmupManager {
             count: warmupCount,
             successCount,
             failureCount: warmupCount - successCount,
-            totalDuration: this.round(totalDuration, 2),
-            averageDuration: this.round(totalDuration / warmupCount, 2),
+            totalDuration: round(totalDuration, 2),
+            averageDuration: round(totalDuration / warmupCount, 2),
             results,
             cacheEffectiveness: CacheEffectivenessAnalyzer.analyze(results),
             timestamp: new Date().toISOString()
@@ -180,17 +181,4 @@ export class WarmupManager {
         this.warmupResults = [];
     }
 
-    /**
-     * Round a number to the specified decimal places.
-     * @param value - Value to round
-     * @param decimals - Number of decimal places
-     * @returns Rounded value, or null if input is invalid
-     */
-    private round(value: number, decimals: number): number | null {
-        if (value === null || value === undefined || isNaN(value)) {
-            return null;
-        }
-        const multiplier = Math.pow(10, decimals);
-        return Math.round(value * multiplier) / multiplier;
-    }
 }

--- a/tests/statistics/distribution-analyzer.test.ts
+++ b/tests/statistics/distribution-analyzer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { DistributionAnalyzer } from '../../lib/statistics/distribution-analyzer.js';
+import { round } from '../../lib/statistics/math-utils.js';
 
 describe('DistributionAnalyzer', () => {
     describe('calculateDistribution', () => {
@@ -58,12 +59,12 @@ describe('DistributionAnalyzer', () => {
 
     describe('round', () => {
         it('rounds correctly', () => {
-            expect(DistributionAnalyzer.round(3.14159, 2)).toBe(3.14);
+            expect(round(3.14159, 2)).toBe(3.14);
         });
 
         it('returns null for null/NaN', () => {
-            expect(DistributionAnalyzer.round(null as unknown as number, 2)).toBeNull();
-            expect(DistributionAnalyzer.round(NaN, 2)).toBeNull();
+            expect(round(null as unknown as number, 2)).toBeNull();
+            expect(round(NaN, 2)).toBeNull();
         });
     });
 });

--- a/tests/statistics/outlier-detector.test.ts
+++ b/tests/statistics/outlier-detector.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { OutlierDetector } from '../../lib/statistics/outlier-detector.js';
+import { calculatePercentile } from '../../lib/statistics/math-utils.js';
 
 describe('OutlierDetector', () => {
     const normalData: number[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -90,11 +91,11 @@ describe('OutlierDetector', () => {
 
     describe('calculatePercentile', () => {
         it('calculates correctly', () => {
-            expect(OutlierDetector.calculatePercentile([1, 2, 3, 4, 5], 50)).toBe(3);
+            expect(calculatePercentile([1, 2, 3, 4, 5], 50)).toBe(3);
         });
 
         it('returns null for empty array', () => {
-            expect(OutlierDetector.calculatePercentile([], 50)).toBeNull();
+            expect(calculatePercentile([], 50)).toBeNull();
         });
     });
 });

--- a/tests/statistics/statistics-calculator.test.ts
+++ b/tests/statistics/statistics-calculator.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { StatisticsCalculator } from '../../lib/statistics/statistics-calculator.js';
+import { round, calculatePercentile } from '../../lib/statistics/math-utils.js';
 
 describe('StatisticsCalculator', () => {
     describe('calculate', () => {
@@ -110,43 +111,43 @@ describe('StatisticsCalculator', () => {
 
     describe('calculatePercentile', () => {
         it('calculates P50 (median) correctly', () => {
-            expect(StatisticsCalculator.calculatePercentile([1, 2, 3, 4, 5], 50)).toBe(3);
+            expect(calculatePercentile([1, 2, 3, 4, 5], 50)).toBe(3);
         });
 
         it('uses linear interpolation', () => {
-            const result = StatisticsCalculator.calculatePercentile([10, 20, 30, 40], 25);
+            const result = calculatePercentile([10, 20, 30, 40], 25);
             expect(result).toBe(17.5);
         });
 
         it('returns single element for single-element array', () => {
-            expect(StatisticsCalculator.calculatePercentile([42], 50)).toBe(42);
+            expect(calculatePercentile([42], 50)).toBe(42);
         });
 
         it('returns null for empty array', () => {
-            expect(StatisticsCalculator.calculatePercentile([], 50)).toBeNull();
+            expect(calculatePercentile([], 50)).toBeNull();
         });
 
         it('throws for invalid percentile', () => {
-            expect(() => StatisticsCalculator.calculatePercentile([1], -1)).toThrow();
-            expect(() => StatisticsCalculator.calculatePercentile([1], 101)).toThrow();
+            expect(() => calculatePercentile([1], -1)).toThrow();
+            expect(() => calculatePercentile([1], 101)).toThrow();
         });
 
         it('handles P0 and P100', () => {
-            expect(StatisticsCalculator.calculatePercentile([1, 2, 3], 0)).toBe(1);
-            expect(StatisticsCalculator.calculatePercentile([1, 2, 3], 100)).toBe(3);
+            expect(calculatePercentile([1, 2, 3], 0)).toBe(1);
+            expect(calculatePercentile([1, 2, 3], 100)).toBe(3);
         });
     });
 
     describe('round', () => {
         it('rounds to specified decimal places', () => {
-            expect(StatisticsCalculator.round(3.14159, 2)).toBe(3.14);
-            expect(StatisticsCalculator.round(3.14159, 3)).toBe(3.142);
+            expect(round(3.14159, 2)).toBe(3.14);
+            expect(round(3.14159, 3)).toBe(3.142);
         });
 
         it('returns null for null/undefined/NaN', () => {
-            expect(StatisticsCalculator.round(null as unknown as number, 2)).toBeNull();
-            expect(StatisticsCalculator.round(undefined as unknown as number, 2)).toBeNull();
-            expect(StatisticsCalculator.round(NaN, 2)).toBeNull();
+            expect(round(null as unknown as number, 2)).toBeNull();
+            expect(round(undefined as unknown as number, 2)).toBeNull();
+            expect(round(NaN, 2)).toBeNull();
         });
     });
 });


### PR DESCRIPTION
## Summary
- Create `lib/statistics/math-utils.ts` with shared `round()` and `calculatePercentile()`
- Remove duplicate implementations from 5 classes (net -69 lines)
- Update tests to import from `math-utils` directly

Closes #42

## Test plan
- [x] `npm run test:unit` — 410 tests pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)