### PR TITLE
fix: change i18n fallback language from ja to en

### DIFF
--- a/web-ui/src/i18n/config.ts
+++ b/web-ui/src/i18n/config.ts
@@ -12,7 +12,7 @@ i18n
       ja: { translation: ja },
       en: { translation: en },
     },
-    fallbackLng: 'ja',
+    fallbackLng: 'en',
     interpolation: {
       escapeValue: false, // React already escapes
     },


### PR DESCRIPTION
## Summary
Change `fallbackLng` from `'ja'` to `'en'` for better OSS inclusivity. Japanese users with browser locale set to `ja` will still see Japanese UI via language detection.

Closes #53

## Test plan
- [x] Verify fallback works when localStorage/navigator have no match
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)