### PR TITLE
chore: replace deprecated mysql_native_password flag

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -18,6 +18,6 @@ services:
       retries: 12
       start_period: 30s
     command:
-      - --default-authentication-plugin=mysql_native_password
+      - --mysql-native-password=ON
       - --performance_schema=ON
       - --optimizer_trace_max_mem_size=1000000


### PR DESCRIPTION
## Summary
Replace `--default-authentication-plugin=mysql_native_password` (deprecated in MySQL 8.0.34+) with `--mysql-native-password=ON`.

Closes #56

## Test plan
- [ ] `docker compose -f docker-compose.test.yml up -d` starts successfully
- [ ] `npm run test:integration` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)