### PR TITLE
fix: prevent OptimizerTrace side effects on non-SELECT queries

### DIFF
--- a/lib/analyzers/optimizer-trace-analyzer.ts
+++ b/lib/analyzers/optimizer-trace-analyzer.ts
@@ -23,6 +23,12 @@ export class OptimizerTraceAnalyzer extends BaseAnalyzer {
             return null;
         }
 
+        // Skip non-SELECT queries to avoid unintended side effects
+        if (!/^\s*SELECT/i.test(query)) {
+            console.warn('Optimizer Trace skipped: only SELECT queries are supported (non-SELECT queries would cause side effects)');
+            return null;
+        }
+
         let traceConnection: PoolConnection | null = null;
         try {
             traceConnection = await this.connection.getConnection();
@@ -40,9 +46,6 @@ export class OptimizerTraceAnalyzer extends BaseAnalyzer {
                 'SELECT TRACE FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE'
             ) as [RowDataPacket[], unknown];
 
-            // Disable optimizer trace
-            await traceConnection.query('SET optimizer_trace="enabled=off"');
-
             if (rows.length > 0) {
                 return {
                     trace: JSON.parse((rows[0].TRACE as string).replace(/\/\*[\s\S]*?\*\//g, '')) as Record<string, unknown>,
@@ -55,7 +58,13 @@ export class OptimizerTraceAnalyzer extends BaseAnalyzer {
             console.warn(`Optimizer Trace capture error: ${(error as Error).message}`);
             return null;
         } finally {
+            // Always disable trace and release connection
             if (traceConnection) {
+                try {
+                    await traceConnection.query('SET optimizer_trace="enabled=off"');
+                } catch {
+                    // Best-effort cleanup
+                }
                 traceConnection.release();
             }
         }


### PR DESCRIPTION
## Summary
- Skip non-SELECT queries to avoid executing INSERT/UPDATE/DELETE an extra time
- Move `SET optimizer_trace="enabled=off"` to finally block for guaranteed cleanup
- Add warning log when non-SELECT queries are skipped

Closes #45

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)