### PR TITLE
fix: add rate limiting to ws-token and connection test endpoints

### DIFF
--- a/web/routes/connections.ts
+++ b/web/routes/connections.ts
@@ -6,6 +6,7 @@
 
 import { Router } from 'express';
 import type { Request, Response } from 'express';
+import rateLimit from 'express-rate-limit';
 import * as store from '../store/connections-store.js';
 import { DatabaseConnection } from '../../lib/core/database-connection.js';
 import { createDbConfig } from '../../lib/config/database-configuration.js';
@@ -13,6 +14,14 @@ import { validateId } from '../security/validate-id.js';
 import { asyncHandler } from '../middleware/async-handler.js';
 
 const router: Router = Router();
+
+const connectionTestRateLimit = rateLimit({
+  windowMs: 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { success: false, error: 'Too many connection test requests. Please try again later.' }
+});
 
 /** List all connections */
 router.get('/', asyncHandler(async (_req: Request, res: Response) => {
@@ -57,7 +66,7 @@ router.delete('/:id', asyncHandler(async (req: Request, res: Response) => {
 }));
 
 /** Test connectivity (SELECT 1) */
-router.post('/:id/test', asyncHandler(async (req: Request, res: Response) => {
+router.post('/:id/test', connectionTestRateLimit, asyncHandler(async (req: Request, res: Response) => {
   const id = validateId(req.params.id as string, '接続ID');
   const connectionData = await store.getById(id);
   if (!connectionData) {

--- a/web/server.ts
+++ b/web/server.ts
@@ -176,7 +176,14 @@ app.use('/api/reports', reportsRouter);
 app.use('/api/history', historyRouter);
 
 // ─── WebSocket token endpoint ────────────────────────────────────────────
-app.get('/api/ws-token', (_req: Request, res: Response) => {
+const wsTokenRateLimit = rateLimit({
+  windowMs: 60 * 1000,
+  max: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { success: false, error: 'Too many token requests. Please try again later.' }
+});
+app.get('/api/ws-token', wsTokenRateLimit, (_req: Request, res: Response) => {
   const token = wsTokenManager.generate();
   res.json({ success: true, token });
 });


### PR DESCRIPTION
## Summary
- `/api/ws-token`: max 20 requests/minute per IP
- `/api/connections/:id/test`: max 10 requests/minute per IP

Closes #48

## Test plan
- [x] Rapid requests return 429 after limit
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)