### PR TITLE
fix: align frontend types with backend API response shapes

### DIFF
--- a/web-ui/src/types/index.ts
+++ b/web-ui/src/types/index.ts
@@ -26,8 +26,10 @@ export interface Connection {
   port: number;
   database: string;
   user: string;
-  password: string;
+  passwordMasked: string;
   poolSize: number;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export interface ConnectionFormData {
@@ -56,6 +58,7 @@ export interface SqlItem {
   sql: string;
   category: string;
   description: string;
+  tags?: string;
   updatedAt: string;
   createdAt: string;
 }
@@ -229,7 +232,7 @@ export type RunAction =
 export interface WsMessage {
   type: string;
   testId?: string;
-  data?: TestProgress;
+  data?: TestProgress | SingleTestResult | ParallelResults | ComparisonResult | { message: string };
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
- `Connection.password` → `Connection.passwordMasked` to match `MaskedConnectionRecord`
- `SqlItem` gains optional `tags` field matching backend `SqlRecord`
- `WsMessage.data` widened to accept all possible payloads

Closes #49

## Test plan
- [x] `npm run build` succeeds
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)