### PR TITLE
refactor: unify EXPLAIN ANALYZE implementation

### DIFF
--- a/lib/analyzers/explain-analyzer.ts
+++ b/lib/analyzers/explain-analyzer.ts
@@ -1,6 +1,9 @@
 /**
  * EXPLAIN analysis class
  * Handles execution and analysis of EXPLAIN and EXPLAIN ANALYZE (MySQL 8.0.18+)
+ *
+ * This is the single authoritative implementation for EXPLAIN ANALYZE.
+ * Other modules should delegate here instead of duplicating the logic.
  */
 
 import type { RowDataPacket } from 'mysql2/promise';
@@ -34,6 +37,11 @@ export class ExplainAnalyzer extends BaseAnalyzer {
 
     /**
      * Execute EXPLAIN ANALYZE (MySQL 8.0.18+)
+     *
+     * Uses a dedicated connection from the pool for the entire sequence so that
+     * the session variable SET @@explain_json_format_version does not leak into
+     * the shared pool.
+     *
      * @param query - The query to analyze
      * @returns EXPLAIN ANALYZE result, or null if unsupported or on error
      */
@@ -42,17 +50,20 @@ export class ExplainAnalyzer extends BaseAnalyzer {
             return null;
         }
 
+        const conn = await this.connection.getConnection();
         try {
-            const [rows] = await this.connection.query(`EXPLAIN ANALYZE ${query}`) as [RowDataPacket[], unknown];
+            const [rows] = await conn.query<RowDataPacket[]>(`EXPLAIN ANALYZE ${query}`);
 
-            // Check if MySQL 8.3+ supports JSON format
+            // Attempt JSON format output (MySQL 8.3+ with explain_json_format_version = 2).
+            // Both SET and the subsequent EXPLAIN run on the same dedicated connection
+            // so the session variable is isolated and released with the connection.
             let jsonResult: Record<string, unknown> | null = null;
             try {
-                await this.connection.query('SET @@explain_json_format_version = 2');
-                const [jsonRows] = await this.connection.query(`EXPLAIN ANALYZE FORMAT=JSON ${query}`) as [RowDataPacket[], unknown];
+                await conn.query('SET @@explain_json_format_version = 2');
+                const [jsonRows] = await conn.query<RowDataPacket[]>(`EXPLAIN ANALYZE FORMAT=JSON ${query}`);
                 jsonResult = JSON.parse((jsonRows[0]['EXPLAIN'] as string).replace(/\/\*[\s\S]*?\*\//g, '')) as Record<string, unknown>;
             } catch (_jsonError) {
-                // Ignore if JSON format is not available
+                // JSON format not available on this MySQL version -- ignore
             }
 
             return {
@@ -64,6 +75,8 @@ export class ExplainAnalyzer extends BaseAnalyzer {
         } catch (error) {
             console.warn(`EXPLAIN ANALYZE execution error: ${(error as Error).message}`);
             return null;
+        } finally {
+            conn.release();
         }
     }
 }

--- a/lib/core/index.ts
+++ b/lib/core/index.ts
@@ -15,5 +15,4 @@ export type {
     MultipleOptions,
     ExecutionStatistics,
     ExecutionPlanResult,
-    ExplainAnalyzeResult,
 } from './query-executor.js';

--- a/lib/core/query-executor.ts
+++ b/lib/core/query-executor.ts
@@ -61,14 +61,6 @@ export interface ExecutionPlanResult {
     timestamp: string;
 }
 
-/** EXPLAIN ANALYZE result */
-export interface ExplainAnalyzeResult {
-    type: string;
-    tree: string;
-    json: unknown;
-    timestamp: string;
-}
-
 /**
  * Assert that a query contains only a single SQL statement.
  *
@@ -281,49 +273,6 @@ export class QueryExecutor {
             };
         } catch (error) {
             console.warn(`Failed to get execution plan: ${(error as Error).message}`);
-            return null;
-        }
-    }
-
-    /**
-     * Execute EXPLAIN ANALYZE (MySQL 8.0.18+)
-     * @param query - SQL query
-     * @returns EXPLAIN ANALYZE result, or null if unsupported/failed
-     */
-    async getExplainAnalyze(query: string): Promise<ExplainAnalyzeResult | null> {
-        if (!this.db.isExplainAnalyzeSupported()) {
-            console.warn('EXPLAIN ANALYZE is not supported on this MySQL version');
-            return null;
-        }
-
-        try {
-            assertSingleStatement(query);
-
-            const [rows] = await this.db.query(`EXPLAIN ANALYZE ${query}`);
-
-            // Also attempt JSON format.
-            // SET @@explain_json_format_version is a session variable,
-            // so SET and EXPLAIN must run on the same connection.
-            let jsonResult: unknown = null;
-            const conn = await this.db.getConnection();
-            try {
-                await conn.query('SET @@explain_json_format_version = 2');
-                const [jsonRows] = await conn.query<RowDataPacket[]>(`EXPLAIN ANALYZE FORMAT=JSON ${query}`);
-                jsonResult = JSON.parse(jsonRows[0]['EXPLAIN'] as string);
-            } catch (_jsonError) {
-                // JSON format may not be available -- ignore
-            } finally {
-                conn.release();
-            }
-
-            return {
-                type: 'EXPLAIN_ANALYZE',
-                tree: rows[0]['EXPLAIN'] as string,
-                json: jsonResult,
-                timestamp: new Date().toISOString()
-            };
-        } catch (error) {
-            console.warn(`Failed to execute EXPLAIN ANALYZE: ${(error as Error).message}`);
             return null;
         }
     }

--- a/lib/testers/single-tester.ts
+++ b/lib/testers/single-tester.ts
@@ -22,7 +22,7 @@ import { ExplainAnalyzer, OptimizerTraceAnalyzer, PerformanceSchemaAnalyzer, Buf
 import { WarmupManager } from '../warmup/index.js';
 import type { WarmupSummary } from '../warmup/warmup-manager.js';
 import { FileManager } from '../storage/file-manager.js';
-import type { DbConfig, TestConfig, ExplainAnalyzeResult } from '../types/index.js';
+import type { DbConfig, TestConfig } from '../types/index.js';
 
 /** Analyzers container */
 interface Analyzers {
@@ -286,13 +286,12 @@ export class MySQLPerformanceTester extends EventEmitter {
         testResult.explainAnalyze = await this.analyzers!.explain.analyzeQuery(query);
 
         // EXPLAIN ANALYZE (MySQL 8.0.18+)
+        // When available, the EXPLAIN ANALYZE result replaces the plain EXPLAIN result
+        // because it is a strict superset (includes actual execution metrics).
         if (this.testConfig.enableExplainAnalyze && this.db!.isExplainAnalyzeSupported()) {
             const explainAnalyzeResult = await this.analyzers!.explain.analyzeQueryWithExecution(query);
-            if (explainAnalyzeResult && testResult.explainAnalyze) {
-                testResult.explainAnalyze = {
-                    ...testResult.explainAnalyze,
-                    ...explainAnalyzeResult,
-                } as ExplainAnalyzeResult;
+            if (explainAnalyzeResult) {
+                testResult.explainAnalyze = explainAnalyzeResult;
                 await this.fileManager.saveExplainAnalyze({ ...explainAnalyzeResult }, testResult.testName);
             }
         }

--- a/tests/integration/core/query-executor.integration.test.ts
+++ b/tests/integration/core/query-executor.integration.test.ts
@@ -143,15 +143,9 @@ describe('QueryExecutor (integration)', () => {
         });
     });
 
-    describe('getExplainAnalyze()', () => {
-        it('should return EXPLAIN ANALYZE result', async () => {
-            const result = await executor.getExplainAnalyze(TEST_QUERIES.simpleSelect);
-            expect(result).not.toBeNull();
-            expect(result!.type).toBe('EXPLAIN_ANALYZE');
-            expect(typeof result!.tree).toBe('string');
-            expect(result!.tree.length).toBeGreaterThan(0);
-        });
-    });
+    // NOTE: getExplainAnalyze() was removed from QueryExecutor.
+    // EXPLAIN ANALYZE is now exclusively handled by ExplainAnalyzer.
+    // See tests/integration/analyzers/explain-analyzer.integration.test.ts
 
     describe('getExecutionStatistics()', () => {
         it('should calculate statistics from results', async () => {


### PR DESCRIPTION
## Summary
- Fix `ExplainAnalyzer.analyzeQueryWithExecution()` to use dedicated connection for session variables (prevents leak)
- Remove duplicate `getExplainAnalyze()` from `QueryExecutor` (-51 lines)
- Fix type merge problem in `SingleTester.runAnalysis()` (no more spread-merge of incompatible types)
- Update integration test accordingly

Closes #43

## Test plan
- [x] `npm run test:unit` — core tests pass
- [ ] `npm run test:integration` — verify EXPLAIN ANALYZE works with real MySQL
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)