### PR TITLE
refactor: type-safe ReportGenerator (#47)

### DIFF
--- a/lib/reports/recommendation-engine.ts
+++ b/lib/reports/recommendation-engine.ts
@@ -3,7 +3,7 @@
  * Generates recommendations based on test results
  */
 
-interface RecommendationItem {
+export interface RecommendationItem {
     priority: string;
     category: string;
     title: string;
@@ -57,7 +57,7 @@ interface ReportSummary {
     [key: string]: unknown;
 }
 
-interface InternalReportData {
+export interface InternalReportData {
     summary: ReportSummary;
     details: ReportDetail[];
     recommendations?: RecommendationItem[];

--- a/lib/reports/report-analyzer.ts
+++ b/lib/reports/report-analyzer.ts
@@ -16,7 +16,7 @@ interface OverallMetrics {
     avgQPS: string | null;
 }
 
-interface ReportSummary {
+export interface ReportSummary {
     testCount: TestCount;
     overallMetrics: OverallMetrics;
     performanceGrade: string;
@@ -131,7 +131,7 @@ interface ParallelResultsData {
     [key: string]: unknown;
 }
 
-interface TestResultInput {
+export interface TestResultInput {
     testName: string;
     query?: string;
     timestamp?: string;
@@ -145,7 +145,7 @@ interface TestResultInput {
     [key: string]: unknown;
 }
 
-interface TestAnalysis {
+export interface TestAnalysis {
     testName: string;
     query?: string;
     timestamp?: string;

--- a/lib/reports/report-generator.ts
+++ b/lib/reports/report-generator.ts
@@ -4,10 +4,10 @@
  */
 
 import { ReportAnalyzer } from './report-analyzer.js';
+import type { ReportSummary, TestResultInput, TestAnalysis } from './report-analyzer.js';
 import { RecommendationEngine } from './recommendation-engine.js';
+import type { RecommendationItem, InternalReportData } from './recommendation-engine.js';
 import { BaseExporter } from './exporters/base-exporter.js';
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 interface ReportMetadata {
     generatedAt: string;
@@ -15,27 +15,27 @@ interface ReportMetadata {
     configuration: Record<string, unknown>;
 }
 
-interface ReportData {
+export interface ReportData {
     metadata: ReportMetadata;
-    summary: any;
-    details: any[];
-    recommendations: any[];
+    summary: ReportSummary | null;
+    details: TestAnalysis[];
+    recommendations: RecommendationItem[];
 }
 
 interface ReportGeneratorDeps {
     analyzer?: ReportAnalyzer;
-    recommendationEngineFactory?: (reportData: any) => RecommendationEngine;
+    recommendationEngineFactory?: (reportData: InternalReportData) => RecommendationEngine;
 }
 
 /**
  * Report generator class
  */
 export class ReportGenerator {
-    testResults: any[];
+    testResults: TestResultInput[];
     config: Record<string, unknown>;
     reportData: ReportData;
     analyzer: ReportAnalyzer;
-    private _recommendationEngineFactory: (reportData: any) => RecommendationEngine;
+    private _recommendationEngineFactory: (reportData: InternalReportData) => RecommendationEngine;
     private _analyzed: boolean;
 
     /**
@@ -43,8 +43,8 @@ export class ReportGenerator {
      * @param config - Plain object returned by createTestConfig()
      * @param deps - Dependency injection (for testing/customization)
      */
-    constructor(testResults: any[], config: Record<string, unknown>, deps: ReportGeneratorDeps = {}) {
-        this.testResults = testResults;
+    constructor(testResults: unknown[], config: Record<string, unknown>, deps: ReportGeneratorDeps = {}) {
+        this.testResults = testResults as TestResultInput[];
         this.config = config;
         this.reportData = {
             metadata: {
@@ -56,9 +56,9 @@ export class ReportGenerator {
             details: [],
             recommendations: []
         };
-        this.analyzer = deps.analyzer ?? new ReportAnalyzer(testResults, config);
+        this.analyzer = deps.analyzer ?? new ReportAnalyzer(this.testResults, config);
         this._recommendationEngineFactory =
-            deps.recommendationEngineFactory ?? ((reportData: any) => new RecommendationEngine(reportData));
+            deps.recommendationEngineFactory ?? ((reportData: InternalReportData) => new RecommendationEngine(reportData));
         this._analyzed = false;
     }
 
@@ -78,7 +78,9 @@ export class ReportGenerator {
         }
 
         // Generate recommendations
-        const recommendationEngine = this._recommendationEngineFactory(this.reportData);
+        const recommendationEngine = this._recommendationEngineFactory(
+            this.reportData as unknown as InternalReportData
+        );
         this.reportData.recommendations = recommendationEngine.generateRecommendations();
 
         this._analyzed = true;
@@ -122,21 +124,21 @@ export class ReportGenerator {
     /**
      * Get summary
      */
-    getSummary(): any {
+    getSummary(): ReportSummary | null {
         return this.reportData.summary;
     }
 
     /**
      * Get recommendations
      */
-    getRecommendations(): any[] {
+    getRecommendations(): RecommendationItem[] {
         return this.reportData.recommendations;
     }
 
     /**
      * Get test details
      */
-    getTestDetails(): any[] {
+    getTestDetails(): TestAnalysis[] {
         return this.reportData.details;
     }
 }

--- a/tests/reports/recommendation-engine.test.ts
+++ b/tests/reports/recommendation-engine.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { RecommendationEngine } from '../../lib/reports/recommendation-engine.js';
+import type { InternalReportData } from '../../lib/reports/recommendation-engine.js';
 
 /**
  * Helper to create minimal report data for the RecommendationEngine
  */
-function createReportData(overrides: Record<string, unknown> = {}) {
+function createReportData(overrides: Record<string, unknown> = {}): InternalReportData {
     return {
         summary: {
             overallMetrics: {
@@ -13,7 +14,7 @@ function createReportData(overrides: Record<string, unknown> = {}) {
             },
             ...(overrides.summary as Record<string, unknown> || {}),
         },
-        details: (overrides.details as unknown[]) || [],
+        details: (overrides.details || []) as InternalReportData['details'],
         recommendations: [],
     };
 }


### PR DESCRIPTION
## Summary
- **report-generator.ts** — `eslint-disable @typescript-eslint/no-explicit-any` 削除、全 `any` を具体型に置換
- **report-analyzer.ts** — `ReportSummary`, `TestResultInput`, `TestAnalysis` をエクスポート
- **recommendation-engine.ts** — `RecommendationItem`, `InternalReportData` をエクスポート
- **tests/reports/recommendation-engine.test.ts** — ヘルパー関数を `InternalReportData` 型に修正

## Test plan
- [x] `npx vitest run --project unit` — 445 tests passed
- [x] `npx tsc --noEmit` — ソースコード・テストファイルともにエラーゼロ

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)