### PR TITLE
fix: align frontend types with backend for distribution, EXPLAIN, and recommendations (#70)

### DIFF
--- a/web-ui/src/components/ExplainPanel.tsx
+++ b/web-ui/src/components/ExplainPanel.tsx
@@ -18,10 +18,16 @@ export default function ExplainPanel({ explain }: Props) {
       {explain.data != null && (
         <div className="code-block">{JSON.stringify(explain.data, null, 2)}</div>
       )}
-      {explain.analyze?.tree && (
+      {explain.json != null && (
+        <>
+          <div className="section-title mt-4">EXPLAIN JSON</div>
+          <div className="code-block">{JSON.stringify(explain.json, null, 2)}</div>
+        </>
+      )}
+      {explain.tree && (
         <>
           <div className="section-title mt-4">{t('components.explainAnalyze')}</div>
-          <div className="code-block">{explain.analyze.tree}</div>
+          <div className="code-block">{explain.tree}</div>
         </>
       )}
     </div>

--- a/web-ui/src/components/HistogramChart.tsx
+++ b/web-ui/src/components/HistogramChart.tsx
@@ -16,8 +16,8 @@ interface Props {
 export default function HistogramChart({ distribution }: Props) {
   const { t } = useTranslation();
 
-  if (!distribution?.buckets) return <div className="empty-state"><p>{t('components.distributionNoData')}</p></div>;
-  const data = distribution.buckets.map(b => ({ name: `${b.min?.toFixed(0)}ms`, count: b.count }));
+  if (!distribution?.bins) return <div className="empty-state"><p>{t('components.distributionNoData')}</p></div>;
+  const data = distribution.bins.map(b => ({ name: `${b.start.toFixed(1)}ms`, count: b.count }));
   return (
     <ResponsiveContainer width="100%" height={220}>
       <BarChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>

--- a/web-ui/src/components/OverlaidHistogram.tsx
+++ b/web-ui/src/components/OverlaidHistogram.tsx
@@ -17,25 +17,25 @@ interface Props {
 
 export default function OverlaidHistogram({ distributionA, distributionB, nameA, nameB }: Props) {
   const { t } = useTranslation();
-  const bucketsA = distributionA?.buckets;
-  const bucketsB = distributionB?.buckets;
+  const binsA = distributionA?.bins;
+  const binsB = distributionB?.bins;
 
-  if (!bucketsA && !bucketsB) {
+  if (!binsA && !binsB) {
     return <div className="empty-state"><p>{t('components.distributionNoData')}</p></div>;
   }
 
-  // Build a unified set of bucket labels from both distributions
+  // Build a unified set of bin labels from both distributions
   const labelMap = new Map<string, { countA: number; countB: number }>();
 
-  bucketsA?.forEach(b => {
-    const label = `${b.min?.toFixed(0)}`;
+  binsA?.forEach(b => {
+    const label = `${b.start.toFixed(1)}`;
     const entry = labelMap.get(label) || { countA: 0, countB: 0 };
     entry.countA = b.count;
     labelMap.set(label, entry);
   });
 
-  bucketsB?.forEach(b => {
-    const label = `${b.min?.toFixed(0)}`;
+  binsB?.forEach(b => {
+    const label = `${b.start.toFixed(1)}`;
     const entry = labelMap.get(label) || { countA: 0, countB: 0 };
     entry.countB = b.count;
     labelMap.set(label, entry);

--- a/web-ui/src/components/RecommendPanel.tsx
+++ b/web-ui/src/components/RecommendPanel.tsx
@@ -7,14 +7,76 @@ import type { QueryPlan } from '../types';
 
 interface Props {
   plan: QueryPlan | undefined;
+  explainTree?: string;
 }
 
-export default function RecommendPanel({ plan }: Props) {
+/**
+ * Analyze EXPLAIN tree text for common performance issues.
+ * Returns issues and recommendations arrays.
+ */
+function analyzeExplainTree(tree: string): { issues: string[]; recommendations: string[] } {
+  const issues: string[] = [];
+  const recommendations: string[] = [];
+  const lower = tree.toLowerCase();
+
+  if (lower.includes('full table scan') || lower.includes('table scan')) {
+    issues.push('Full table scan detected');
+    recommendations.push('Consider adding an index on the columns used in WHERE / JOIN clauses');
+  }
+  if (lower.includes('filesort')) {
+    issues.push('Filesort operation detected');
+    recommendations.push('Consider adding an index that covers the ORDER BY columns');
+  }
+  if (lower.includes('temporary')) {
+    issues.push('Temporary table created');
+    recommendations.push('Review GROUP BY / DISTINCT usage; an index covering these columns may eliminate the temporary table');
+  }
+  if (lower.includes('nested loop')) {
+    recommendations.push('Nested loop join detected — ensure join columns are indexed');
+  }
+
+  return { issues, recommendations };
+}
+
+export default function RecommendPanel({ plan, explainTree }: Props) {
   const { t } = useTranslation();
 
-  if (!plan) return <div className="empty-state"><p>{t('components.recommendNoData')}</p></div>;
-  const issues = plan.issues || [];
-  const recs = plan.recommendations || [];
+  // Use explicit queryPlan if available, otherwise analyze EXPLAIN tree
+  const issues = plan?.issues || [];
+  const recs = plan?.recommendations || [];
+  const hasExplicitPlan = issues.length > 0 || recs.length > 0;
+
+  if (!hasExplicitPlan && explainTree) {
+    const analysis = analyzeExplainTree(explainTree);
+    return (
+      <div>
+        {analysis.issues.length > 0 && (
+          <>
+            <div className="section-title">{t('components.issuesDetected')}</div>
+            {analysis.issues.map((iss, i) => (
+              <div key={i} className="alert alert-error" style={{ marginBottom: 8 }}>{iss}</div>
+            ))}
+          </>
+        )}
+        {analysis.recommendations.length > 0 && (
+          <>
+            <div className="section-title mt-4">{t('components.recommendations')}</div>
+            {analysis.recommendations.map((rec, i) => (
+              <div key={i} className="alert alert-info" style={{ marginBottom: 8 }}>{rec}</div>
+            ))}
+          </>
+        )}
+        {analysis.issues.length === 0 && analysis.recommendations.length === 0 && (
+          <div className="empty-state"><p>{t('components.noIssues')}</p></div>
+        )}
+      </div>
+    );
+  }
+
+  if (!hasExplicitPlan) {
+    return <div className="empty-state"><p>{t('components.recommendNoData')}</p></div>;
+  }
+
   return (
     <div>
       {issues.length > 0 && (

--- a/web-ui/src/pages/ComparisonTest.tsx
+++ b/web-ui/src/pages/ComparisonTest.tsx
@@ -400,11 +400,11 @@ export default function ComparisonTest({ wsMessages, subscribeTestId }: Props) {
               <div className="card-grid card-grid-2">
                 <div>
                   <div className="section-title">{comparison.testNameA}</div>
-                  <RecommendPanel plan={comparison.resultA?.explainAnalyze?.queryPlan} />
+                  <RecommendPanel plan={comparison.resultA?.explainAnalyze?.queryPlan} explainTree={comparison.resultA?.explainAnalyze?.tree} />
                 </div>
                 <div>
                   <div className="section-title">{comparison.testNameB}</div>
-                  <RecommendPanel plan={comparison.resultB?.explainAnalyze?.queryPlan} />
+                  <RecommendPanel plan={comparison.resultB?.explainAnalyze?.queryPlan} explainTree={comparison.resultB?.explainAnalyze?.tree} />
                 </div>
               </div>
             )}

--- a/web-ui/src/pages/SingleTest.tsx
+++ b/web-ui/src/pages/SingleTest.tsx
@@ -254,7 +254,7 @@ export default function SingleTest({ wsMessages, subscribeTestId }: Props) {
             )}
 
             {activeTab === 'recommend' && (
-              <RecommendPanel plan={run.result.explainAnalyze?.queryPlan} />
+              <RecommendPanel plan={run.result.explainAnalyze?.queryPlan} explainTree={run.result.explainAnalyze?.tree} />
             )}
           </div>
         )}

--- a/web-ui/src/types/index.ts
+++ b/web-ui/src/types/index.ts
@@ -122,14 +122,17 @@ export interface CountStats {
   outliers?: number;
 }
 
-export interface DistributionBucket {
-  min?: number;
-  max?: number;
+export interface DistributionBin {
+  start: number;
+  end: number;
   count: number;
+  percentage: number;
 }
 
 export interface Distribution {
-  buckets?: DistributionBucket[];
+  bins?: DistributionBin[];
+  binCount?: number;
+  binWidth?: number;
 }
 
 export interface Statistics {
@@ -141,10 +144,11 @@ export interface Statistics {
 }
 
 export interface ExplainAnalyze {
-  data?: unknown;
-  analyze?: {
-    tree?: string;
-  };
+  type?: 'EXPLAIN' | 'EXPLAIN_ANALYZE';
+  data?: Record<string, unknown>;
+  tree?: string;
+  json?: Record<string, unknown> | null;
+  timestamp?: string;
   queryPlan?: QueryPlan;
 }
 


### PR DESCRIPTION
## Summary
- Fix Distribution type: `buckets`→`bins`, `min/max`→`start/end`, add `binCount`/`binWidth`
- Fix ExplainAnalyze type: `analyze.tree`→`tree`, add `json`/`type`/`timestamp` fields
- Enhance RecommendPanel to analyze EXPLAIN tree for common performance issues (full table scan, filesort, temporary tables) when `queryPlan` is unavailable

## Test plan
- [x] ESLint clean
- [x] Production build succeeds
- [x] Existing unit tests pass (26/27 — 1 pre-existing i18n failure unrelated to this change)
- [x] Manual verification: histogram, EXPLAIN tree, and recommendations all display correctly after test execution

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)