### PR TITLE
fix: add division-by-zero guards and unify variance to N-1 (#74)

### DIFF
--- a/lib/models/test-result.ts
+++ b/lib/models/test-result.ts
@@ -13,6 +13,7 @@
  */
 
 import { StatisticsCalculator } from '../statistics/statistics-calculator.js';
+import { sampleStdDev } from '../statistics/math-utils.js';
 import type {
     StatisticsResult,
     BufferPoolAnalysisResult,
@@ -173,9 +174,7 @@ export class TestResult {
         const avg = durations.reduce((a, b) => a + b, 0) / durations.length;
         const min = Math.min(...durations);
         const max = Math.max(...durations);
-        const stdDev = Math.sqrt(
-            durations.reduce((a, b) => a + Math.pow(b - avg, 2), 0) / durations.length
-        );
+        const stdDev = sampleStdDev(durations);
 
         return {
             success: successResults.length,

--- a/lib/statistics/distribution-analyzer.ts
+++ b/lib/statistics/distribution-analyzer.ts
@@ -21,6 +21,21 @@ export class DistributionAnalyzer {
 
         const min = sortedArray[0];
         const max = sortedArray[sortedArray.length - 1];
+
+        // Guard: all values identical — return single bin
+        if (max === min) {
+            return {
+                bins: [{
+                    start: round(min, 3)!,
+                    end: round(min, 3)!,
+                    count: sortedArray.length,
+                    percentage: 100
+                }],
+                binCount: 1,
+                binWidth: 0
+            };
+        }
+
         const binWidth = (max - min) / binCount;
 
         const bins: DistributionBin[] = Array(binCount).fill(0).map((_, i) => ({

--- a/lib/statistics/math-utils.ts
+++ b/lib/statistics/math-utils.ts
@@ -17,6 +17,21 @@ export function round(value: number, decimals: number): number | null {
 }
 
 /**
+ * Calculate sample standard deviation using Bessel's correction (N-1)
+ * Returns 0 for arrays with fewer than 2 elements or when all values are identical
+ * @param values - Numeric array
+ * @returns Sample standard deviation
+ */
+export function sampleStdDev(values: number[]): number {
+    if (values.length < 2) {
+        return 0;
+    }
+    const mean = values.reduce((a, b) => a + b, 0) / values.length;
+    const sumSquaredDev = values.reduce((s, val) => s + Math.pow(val - mean, 2), 0);
+    return Math.sqrt(sumSquaredDev / (values.length - 1));
+}
+
+/**
  * Calculate a percentile from a pre-sorted numeric array using linear interpolation
  * @param sortedArray - Pre-sorted numeric array
  * @param percentile - Percentile value (0-100)

--- a/lib/statistics/outlier-detector.ts
+++ b/lib/statistics/outlier-detector.ts
@@ -3,7 +3,7 @@
  * Detects and removes outliers using multiple statistical methods
  */
 
-import { round, calculatePercentile } from './math-utils.js';
+import { round, calculatePercentile, sampleStdDev } from './math-utils.js';
 
 interface OutlierResult {
     filtered: number[];
@@ -78,12 +78,14 @@ export class OutlierDetector {
      * @returns Filtered data with outlier information
      */
     static removeOutliersZScore(sortedArray: number[], threshold: number = 3): OutlierResult {
-        const mean = sortedArray.reduce((a, b) => a + b, 0) / sortedArray.length;
-        const stdDev = Math.sqrt(
-            sortedArray.reduce((sum, val) => sum + Math.pow(val - mean, 2), 0) /
-            sortedArray.length
-        );
+        const stdDev = sampleStdDev(sortedArray);
 
+        // If stdDev is 0 (all values identical), no outliers possible
+        if (stdDev === 0) {
+            return { filtered: [...sortedArray], outliers: [] };
+        }
+
+        const mean = sortedArray.reduce((a, b) => a + b, 0) / sortedArray.length;
         const filtered: number[] = [];
         const outliers: number[] = [];
 
@@ -109,6 +111,11 @@ export class OutlierDetector {
         const median = calculatePercentile(sortedArray, 50)!;
         const deviations = sortedArray.map(val => Math.abs(val - median));
         const madValue = calculatePercentile(deviations.sort((a, b) => a - b), 50)!;
+
+        // If MAD is 0 (all values identical or nearly so), no outliers possible
+        if (madValue === 0) {
+            return { filtered: [...sortedArray], outliers: [] };
+        }
 
         // Modified Z-score = 0.6745 * (x - median) / MAD
         const filtered: number[] = [];

--- a/lib/statistics/statistics-calculator.ts
+++ b/lib/statistics/statistics-calculator.ts
@@ -56,8 +56,8 @@ export class StatisticsCalculator {
             : 0;
         const stdDev = Math.sqrt(variance);
 
-        // Coefficient of Variation
-        const cv = (stdDev / mean) * 100;
+        // Coefficient of Variation (guard against mean === 0)
+        const cv = mean !== 0 ? (stdDev / mean) * 100 : 0;
 
         // Percentiles
         const percentiles: Percentiles = {

--- a/tests/statistics/distribution-analyzer.test.ts
+++ b/tests/statistics/distribution-analyzer.test.ts
@@ -57,6 +57,27 @@ describe('DistributionAnalyzer', () => {
         });
     });
 
+    describe('calculateDistribution - edge cases', () => {
+        it('handles all-identical values without division by zero', () => {
+            const data = [7, 7, 7, 7, 7];
+            const result = DistributionAnalyzer.calculateDistribution(data);
+
+            expect(result.binCount).toBe(1);
+            expect(result.binWidth).toBe(0);
+            expect(result.bins.length).toBe(1);
+            expect(result.bins[0].count).toBe(5);
+            expect(result.bins[0].percentage).toBe(100);
+        });
+
+        it('handles single-element array', () => {
+            const result = DistributionAnalyzer.calculateDistribution([42]);
+
+            expect(result.binCount).toBe(1);
+            expect(result.bins[0].count).toBe(1);
+            expect(result.bins[0].percentage).toBe(100);
+        });
+    });
+
     describe('round', () => {
         it('rounds correctly', () => {
             expect(round(3.14159, 2)).toBe(3.14);

--- a/tests/statistics/outlier-detector.test.ts
+++ b/tests/statistics/outlier-detector.test.ts
@@ -77,6 +77,15 @@ describe('OutlierDetector', () => {
         });
     });
 
+    describe('removeOutliersZScore - edge cases', () => {
+        it('handles all-identical values without division by zero', () => {
+            const data = [5, 5, 5, 5, 5];
+            const result = OutlierDetector.removeOutliersZScore(data);
+            expect(result.filtered).toEqual(data);
+            expect(result.outliers).toEqual([]);
+        });
+    });
+
     describe('removeOutliersMAD', () => {
         it('keeps normal data intact', () => {
             const result = OutlierDetector.removeOutliersMAD(normalData);
@@ -86,6 +95,13 @@ describe('OutlierDetector', () => {
         it('detects extreme outliers', () => {
             const result = OutlierDetector.removeOutliersMAD(dataWithOutlier);
             expect(result.outliers).toContain(100);
+        });
+
+        it('handles all-identical values without division by zero', () => {
+            const data = [3, 3, 3, 3, 3];
+            const result = OutlierDetector.removeOutliersMAD(data);
+            expect(result.filtered).toEqual(data);
+            expect(result.outliers).toEqual([]);
         });
     });
 

--- a/tests/statistics/statistics-calculator.test.ts
+++ b/tests/statistics/statistics-calculator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { StatisticsCalculator } from '../../lib/statistics/statistics-calculator.js';
-import { round, calculatePercentile } from '../../lib/statistics/math-utils.js';
+import { round, calculatePercentile, sampleStdDev } from '../../lib/statistics/math-utils.js';
 
 describe('StatisticsCalculator', () => {
     describe('calculate', () => {
@@ -107,6 +107,26 @@ describe('StatisticsCalculator', () => {
             expect(result!.basic.min).toBe(1);
             expect(result!.basic.max).toBe(5);
         });
+
+        it('handles all-identical values (CV should be 0, no division by zero)', () => {
+            const data = [5, 5, 5, 5, 5];
+            const result = StatisticsCalculator.calculate(data);
+
+            expect(result!.basic.mean).toBe(5);
+            expect(result!.spread.variance).toBe(0);
+            expect(result!.spread.stdDev).toBe(0);
+            expect(result!.spread.cv).toBe(0);
+            expect(Number.isFinite(result!.spread.cv)).toBe(true);
+        });
+
+        it('handles all-zero values (CV should be 0)', () => {
+            const data = [0, 0, 0, 0, 0];
+            const result = StatisticsCalculator.calculate(data);
+
+            expect(result!.basic.mean).toBe(0);
+            expect(result!.spread.cv).toBe(0);
+            expect(Number.isFinite(result!.spread.cv)).toBe(true);
+        });
     });
 
     describe('calculatePercentile', () => {
@@ -135,6 +155,27 @@ describe('StatisticsCalculator', () => {
         it('handles P0 and P100', () => {
             expect(calculatePercentile([1, 2, 3], 0)).toBe(1);
             expect(calculatePercentile([1, 2, 3], 100)).toBe(3);
+        });
+    });
+
+    describe('sampleStdDev', () => {
+        it('returns 0 for empty array', () => {
+            expect(sampleStdDev([])).toBe(0);
+        });
+
+        it('returns 0 for single element', () => {
+            expect(sampleStdDev([42])).toBe(0);
+        });
+
+        it('returns 0 for all-identical values', () => {
+            expect(sampleStdDev([5, 5, 5, 5])).toBe(0);
+        });
+
+        it('uses Bessel correction (N-1)', () => {
+            // [2, 4, 4, 4, 5, 5, 7, 9] — mean = 5, sum of sq dev = 32
+            // Sample stdDev = sqrt(32/7) ≈ 2.138
+            const result = sampleStdDev([2, 4, 4, 4, 5, 5, 7, 9]);
+            expect(result).toBeCloseTo(Math.sqrt(32 / 7), 10);
         });
     });
 


### PR DESCRIPTION
## Summary
- Add `sampleStdDev()` shared function in `math-utils.ts` using Bessel's correction (N-1)
- Guard CV calculation against `mean === 0` (returns 0 instead of Infinity)
- Fix Z-score outlier detection: use sample stdDev (N-1) instead of population, guard `stdDev === 0`
- Guard MAD outlier detection against `madValue === 0`
- Guard distribution histogram against `max === min` (returns single-bin fallback)
- Fix `test-result.ts` to use `sampleStdDev` instead of population stdDev (N → N-1)

Closes #74

## Test plan
- [x] All 53 statistics tests pass
- [x] New edge case tests: all-identical values, all-zero values, single-element arrays

🤖 Generated with [Claude Code](https://claude.com/claude-code)