### PR TITLE
ci: add npm audit checks to CI pipeline (#78)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,17 @@ jobs:
         run: npm run build
         working-directory: web-ui
 
+      - name: Audit root dependencies
+        run: npm audit --audit-level=high
+
+      - name: Audit web dependencies
+        run: npm audit --audit-level=high
+        working-directory: web
+
+      - name: Audit web-ui dependencies
+        run: npm audit --audit-level=high
+        working-directory: web-ui
+
   integration-test:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
- Add `npm audit --audit-level=high` for root, web/, and web-ui/ in CI `test-and-lint` job
- Prevents merging code with HIGH or CRITICAL dependency vulnerabilities

Closes #78

## Test plan
- [x] CI workflow syntax valid
- [x] Audit steps run after dependency installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)