### PR TITLE
fix: improve frontend API client type safety and add timeout (#80)

### DIFF
--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -31,11 +31,18 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
   const opts: RequestInit = {
     method,
     headers: { 'Content-Type': 'application/json' },
+    signal: AbortSignal.timeout(30_000),
   };
   if (body !== undefined) opts.body = JSON.stringify(body);
 
   const res = await fetch(`${BASE_URL}${path}`, opts);
-  const data: ApiResponse<T> = await res.json();
+
+  let data: ApiResponse<T>;
+  try {
+    data = await res.json();
+  } catch {
+    throw new Error(`Invalid JSON response from server (HTTP ${res.status})`);
+  }
 
   if (!res.ok || !data.success) {
     throw new Error(data.error || `HTTP ${res.status}`);

--- a/web-ui/src/types/index.ts
+++ b/web-ui/src/types/index.ts
@@ -233,12 +233,12 @@ export type RunAction =
 
 // ─── WebSocket ────────────────────────────────────────────────────────────
 
-export interface WsMessage {
-  type: string;
-  testId?: string;
-  data?: TestProgress | SingleTestResult | ParallelResults | ComparisonResult | { message: string };
-  [key: string]: unknown;
-}
+export type WsMessage =
+  | { type: 'connected'; data?: { message: string } }
+  | { type: 'progress'; testId: string; data: TestProgress }
+  | { type: 'complete'; testId: string; data: SingleTestResult | ParallelResults | ComparisonResult }
+  | { type: 'error'; testId: string; data: { message: string } }
+  | { type: string; testId?: string; data?: unknown };
 
 // ─── Reports ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Add `AbortSignal.timeout(30_000)` to all fetch requests to prevent indefinite hangs
- Add explicit JSON parse error handling (distinguishes network vs parse errors)
- Change `WsMessage` from loose `interface` with `[key: string]: unknown` to discriminated union type

Closes #80

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] WsMessage type correctly narrows in existing usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)