### PR TITLE
feat: add 404 Not Found page with i18n support (#82)

### DIFF
--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -13,6 +13,7 @@ import Analytics from './pages/Analytics';
 import ComparisonTest from './pages/ComparisonTest';
 import Settings from './pages/Settings';
 import QueryHistory from './pages/QueryHistory';
+import NotFound from './pages/NotFound';
 
 type NavItem =
   | { section: string; path?: undefined; icon?: undefined; labelKey?: undefined }
@@ -127,6 +128,7 @@ export default function App() {
               <Route path="/analytics" element={<Analytics />} />
               <Route path="/history" element={<QueryHistory />} />
               <Route path="/settings" element={<Settings />} />
+              <Route path="*" element={<NotFound />} />
             </Routes>
           </main>
         </div>

--- a/web-ui/src/i18n/locales/en.json
+++ b/web-ui/src/i18n/locales/en.json
@@ -302,5 +302,9 @@
     "deltaP95": "P95",
     "deltaP99": "P99",
     "deltaMs": "Delta (ms)"
+  },
+  "notFound": {
+    "message": "The page you are looking for does not exist.",
+    "backHome": "Back to Home"
   }
 }

--- a/web-ui/src/i18n/locales/ja.json
+++ b/web-ui/src/i18n/locales/ja.json
@@ -302,5 +302,9 @@
     "deltaP95": "P95",
     "deltaP99": "P99",
     "deltaMs": "Delta (ms)"
+  },
+  "notFound": {
+    "message": "お探しのページは存在しません。",
+    "backHome": "ホームに戻る"
   }
 }

--- a/web-ui/src/pages/NotFound.tsx
+++ b/web-ui/src/pages/NotFound.tsx
@@ -1,0 +1,16 @@
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+export default function NotFound() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="card" style={{ textAlign: 'center', padding: '3rem' }}>
+      <h1>404</h1>
+      <p>{t('notFound.message')}</p>
+      <Link to="/" className="btn btn-primary" style={{ marginTop: '1rem' }}>
+        {t('notFound.backHome')}
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `NotFound` page component with i18n-translated message and home link
- Add catch-all `<Route path="*">` in App.tsx to handle undefined routes
- Add `notFound.message` and `notFound.backHome` keys to en.json and ja.json

Closes #82

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] Navigating to undefined URL shows 404 page

🤖 Generated with [Claude Code](https://claude.com/claude-code)