### PR TITLE
test: add Web API store unit tests (#86)

### DIFF
--- a/tests/web/store/connections-store.test.ts
+++ b/tests/web/store/connections-store.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { initDb, closeDb } from '../../../web/store/database.js';
+import * as store from '../../../web/store/connections-store.js';
+
+describe('ConnectionsStore', () => {
+    beforeEach(() => {
+        initDb(':memory:');
+    });
+
+    afterEach(() => {
+        closeDb();
+    });
+
+    describe('create', () => {
+        it('creates a connection with default values', async () => {
+            const conn = await store.create({});
+            expect(conn.id).toMatch(/^conn_/);
+            expect(conn.name).toMatch(/^Connection \d+$/);
+            expect(conn.host).toBe('localhost');
+            expect(conn.port).toBe(3306);
+            expect(conn.user).toBe('root');
+            expect(conn.poolSize).toBe(10);
+            // Empty password → maskRecord returns '' (no password set)
+            expect(conn.passwordMasked).toBeDefined();
+        });
+
+        it('creates a connection with custom values', async () => {
+            const conn = await store.create({
+                name: 'Test DB',
+                host: '192.168.1.100',
+                port: 3307,
+                database: 'mydb',
+                user: 'admin',
+                password: 'secret',
+                poolSize: 20,
+            });
+            expect(conn.name).toBe('Test DB');
+            expect(conn.host).toBe('192.168.1.100');
+            expect(conn.port).toBe(3307);
+            expect(conn.database).toBe('mydb');
+            expect(conn.user).toBe('admin');
+            expect(conn.poolSize).toBe(20);
+        });
+
+        it('auto-increments name when no name is provided', async () => {
+            const c1 = await store.create({});
+            const c2 = await store.create({});
+            expect(c1.name).toBe('Connection 1');
+            expect(c2.name).toBe('Connection 2');
+        });
+    });
+
+    describe('getAll', () => {
+        it('returns empty array when no connections', async () => {
+            const all = await store.getAll();
+            expect(all).toEqual([]);
+        });
+
+        it('returns all connections with masked passwords', async () => {
+            await store.create({ name: 'A' });
+            await store.create({ name: 'B' });
+            const all = await store.getAll();
+            expect(all).toHaveLength(2);
+            expect(all[0].passwordMasked).toBeDefined();
+            expect(all[1].passwordMasked).toBeDefined();
+        });
+    });
+
+    describe('getById', () => {
+        it('returns null for non-existent ID', async () => {
+            const result = await store.getById('non-existent');
+            expect(result).toBeNull();
+        });
+
+        it('returns connection with decrypted password', async () => {
+            const created = await store.create({ password: 'mypass' });
+            const found = await store.getById(created.id);
+            expect(found).not.toBeNull();
+            expect(found!.id).toBe(created.id);
+            // Password should be decrypted (either plaintext or decrypted depending on ENCRYPTION_KEY)
+            expect(found!.password).toBeDefined();
+        });
+    });
+
+    describe('update', () => {
+        it('returns null for non-existent ID', async () => {
+            const result = await store.update('non-existent', { name: 'New' });
+            expect(result).toBeNull();
+        });
+
+        it('updates name field', async () => {
+            const created = await store.create({ name: 'Old' });
+            const updated = await store.update(created.id, { name: 'New' });
+            expect(updated!.name).toBe('New');
+        });
+
+        it('updates host and port', async () => {
+            const created = await store.create({});
+            const updated = await store.update(created.id, { host: 'db.example.com', port: 5432 });
+            expect(updated!.host).toBe('db.example.com');
+            expect(updated!.port).toBe(5432);
+        });
+
+        it('returns unchanged record when no updates provided', async () => {
+            const created = await store.create({ name: 'Keep' });
+            const updated = await store.update(created.id, {});
+            expect(updated!.name).toBe('Keep');
+        });
+
+        it('updates updatedAt timestamp', async () => {
+            const created = await store.create({});
+            // Small delay to ensure different timestamp
+            const updated = await store.update(created.id, { name: 'Changed' });
+            expect(updated!.updatedAt).toBeDefined();
+        });
+    });
+
+    describe('remove', () => {
+        it('returns false for non-existent ID', async () => {
+            const result = await store.remove('non-existent');
+            expect(result).toBe(false);
+        });
+
+        it('deletes an existing connection', async () => {
+            const created = await store.create({});
+            const result = await store.remove(created.id);
+            expect(result).toBe(true);
+
+            const all = await store.getAll();
+            expect(all).toHaveLength(0);
+        });
+    });
+});

--- a/tests/web/store/sql-store.test.ts
+++ b/tests/web/store/sql-store.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { initDb, closeDb } from '../../../web/store/database.js';
+import * as store from '../../../web/store/sql-store.js';
+
+describe('SqlStore', () => {
+    beforeEach(() => {
+        initDb(':memory:');
+    });
+
+    afterEach(() => {
+        closeDb();
+    });
+
+    describe('create', () => {
+        it('creates a SQL snippet with default values', async () => {
+            const item = await store.create({});
+            expect(item.id).toMatch(/^sql_/);
+            expect(item.name).toBe('Untitled SQL');
+            expect(item.sql).toBe('');
+            expect(item.category).toBe('SELECT');
+            expect(item.tags).toEqual([]);
+        });
+
+        it('creates a SQL snippet with custom values', async () => {
+            const item = await store.create({
+                name: 'Test Query',
+                sql: 'SELECT * FROM users',
+                category: 'select',
+                description: 'Get all users',
+                tags: ['users', 'select'],
+            });
+            expect(item.name).toBe('Test Query');
+            expect(item.sql).toBe('SELECT * FROM users');
+            expect(item.category).toBe('select');
+            expect(item.description).toBe('Get all users');
+            expect(item.tags).toEqual(['users', 'select']);
+        });
+    });
+
+    describe('getAll', () => {
+        it('returns empty array when no items', async () => {
+            const all = await store.getAll();
+            expect(all).toEqual([]);
+        });
+
+        it('returns all items', async () => {
+            await store.create({ name: 'Q1' });
+            await store.create({ name: 'Q2' });
+            const all = await store.getAll();
+            expect(all).toHaveLength(2);
+        });
+
+        it('filters by category', async () => {
+            await store.create({ name: 'Q1', category: 'select' });
+            await store.create({ name: 'Q2', category: 'insert' });
+            const selectOnly = await store.getAll({ category: 'select' });
+            expect(selectOnly).toHaveLength(1);
+            expect(selectOnly[0].category).toBe('select');
+        });
+
+        it('filters by keyword in name', async () => {
+            await store.create({ name: 'User Query', sql: 'SELECT 1' });
+            await store.create({ name: 'Order Query', sql: 'SELECT 2' });
+            const results = await store.getAll({ keyword: 'User' });
+            expect(results).toHaveLength(1);
+            expect(results[0].name).toBe('User Query');
+        });
+    });
+
+    describe('getById', () => {
+        it('returns null for non-existent ID', async () => {
+            const result = await store.getById('non-existent');
+            expect(result).toBeNull();
+        });
+
+        it('returns the correct item', async () => {
+            const created = await store.create({ name: 'Test' });
+            const found = await store.getById(created.id);
+            expect(found).not.toBeNull();
+            expect(found!.name).toBe('Test');
+        });
+    });
+
+    describe('getCategories', () => {
+        it('returns empty array when no items', async () => {
+            const cats = await store.getCategories();
+            expect(cats).toEqual([]);
+        });
+
+        it('returns unique categories', async () => {
+            await store.create({ category: 'select' });
+            await store.create({ category: 'insert' });
+            await store.create({ category: 'select' });
+            const cats = await store.getCategories();
+            expect(cats).toHaveLength(2);
+            expect(cats).toContain('select');
+            expect(cats).toContain('insert');
+        });
+    });
+
+    describe('update', () => {
+        it('returns null for non-existent ID', async () => {
+            const result = await store.update('non-existent', { name: 'New' });
+            expect(result).toBeNull();
+        });
+
+        it('updates fields', async () => {
+            const created = await store.create({ name: 'Old', sql: 'SELECT 1' });
+            const updated = await store.update(created.id, { name: 'New', sql: 'SELECT 2' });
+            expect(updated!.name).toBe('New');
+            expect(updated!.sql).toBe('SELECT 2');
+        });
+
+        it('updates tags', async () => {
+            const created = await store.create({ tags: ['a'] });
+            const updated = await store.update(created.id, { tags: ['a', 'b', 'c'] });
+            expect(updated!.tags).toEqual(['a', 'b', 'c']);
+        });
+    });
+
+    describe('remove', () => {
+        it('returns false for non-existent ID', async () => {
+            const result = await store.remove('non-existent');
+            expect(result).toBe(false);
+        });
+
+        it('deletes an existing item', async () => {
+            const created = await store.create({});
+            const result = await store.remove(created.id);
+            expect(result).toBe(true);
+            const all = await store.getAll();
+            expect(all).toHaveLength(0);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add 29 unit tests for `web/store/` (connections-store, sql-store)
- Use SQLite `:memory:` for test isolation — no disk I/O needed
- Cover CRUD operations, filtering, password masking, auto-naming

Closes #86

## Test plan
- [x] All 29 tests pass
- [x] No external dependencies required

🤖 Generated with [Claude Code](https://claude.com/claude-code)