### PR TITLE
fix: log malformed WebSocket messages (#88)

### DIFF
--- a/web/server.ts
+++ b/web/server.ts
@@ -154,7 +154,7 @@ wss.on('connection', (ws: SubscribableWebSocket, req) => {
         }
       }
     } catch {
-      // Ignore malformed messages
+      console.warn(`[WS] Malformed message from ${clientIp}: ${raw.toString().slice(0, 100)}`);
     }
   });
 


### PR DESCRIPTION
## Summary
- Replace silent catch with `console.warn` for malformed WebSocket messages
- Log first 100 characters of the raw message for debugging

Closes #88

## Test plan
- [x] Existing tests pass
- [x] Change is minimal (1 line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)