### PR TITLE
fix: implement focus trap for modal dialogs (#89)

### DIFF
--- a/web-ui/src/hooks/useFocusTrap.ts
+++ b/web-ui/src/hooks/useFocusTrap.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from 'react';
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Trap focus within a modal/dialog element.
+ * - Tab cycles through focusable elements inside the container
+ * - Esc calls onEscape callback
+ * - Focus is moved into the container on mount and restored on unmount
+ */
+export function useFocusTrap(onEscape?: () => void) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    // Save the previously focused element to restore later
+    previousFocusRef.current = document.activeElement as HTMLElement;
+
+    // Focus the first focusable element inside the container
+    const focusableElements = container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    if (focusableElements.length > 0) {
+      focusableElements[0].focus();
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape' && onEscape) {
+        e.preventDefault();
+        onEscape();
+        return;
+      }
+
+      if (e.key !== 'Tab' || !container) return;
+
+      const focusable = container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        // Shift+Tab: wrap from first to last
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        // Tab: wrap from last to first
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      // Restore focus to previous element
+      previousFocusRef.current?.focus();
+    };
+  }, [onEscape]);
+
+  return containerRef;
+}

--- a/web-ui/src/pages/Connections.tsx
+++ b/web-ui/src/pages/Connections.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { connectionsApi } from '../api/client';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import type { Connection, ConnectionFormData, ConnectionTestResult } from '../types';
 
 interface ConnectionFormProps {
@@ -16,10 +17,11 @@ function ConnectionForm({ initial, onSave, onCancel }: ConnectionFormProps) {
     database: '', user: 'root', password: '', poolSize: 10
   });
   const set = (k: keyof ConnectionFormData, v: string | number) => setForm(f => ({ ...f, [k]: v }));
+  const trapRef = useFocusTrap(onCancel);
 
   return (
     <div className="modal-backdrop" onClick={onCancel}>
-      <div className="modal fade-in" role="dialog" aria-modal="true" aria-labelledby="modal-title" onClick={e => e.stopPropagation()}>
+      <div ref={trapRef} className="modal fade-in" role="dialog" aria-modal="true" aria-labelledby="modal-title" onClick={e => e.stopPropagation()}>
         <div className="modal-header">
           <h3 className="modal-title" id="modal-title">{initial ? t('connections.editTitle') : t('connections.addTitle')}</h3>
           <button className="modal-close" aria-label="Close" onClick={onCancel}>×</button>


### PR DESCRIPTION
## Summary
- Add `useFocusTrap` custom hook with Tab cycling, Shift+Tab reverse, Esc to close
- Saves previously focused element and restores on unmount
- Apply to ConnectionForm modal in Connections page

Closes #89

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] Modal traps focus on open, cycles Tab, Esc closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)