### PR TITLE
perf: add route-level code splitting with React.lazy (#93)

### DIFF
--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -1,18 +1,19 @@
 import { BrowserRouter, Routes, Route, NavLink, useLocation } from 'react-router-dom';
-import { useState, useCallback } from 'react';
+import { lazy, Suspense, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useWebSocket } from './hooks/useWebSocket';
 import type { WsMessage } from './types';
+import PageLoader from './components/PageLoader';
 
-import Connections from './pages/Connections';
-import SqlLibrary from './pages/SqlLibrary';
-import SingleTest from './pages/SingleTest';
-import ParallelTest from './pages/ParallelTest';
-import Reports from './pages/Reports';
-import Analytics from './pages/Analytics';
-import ComparisonTest from './pages/ComparisonTest';
-import Settings from './pages/Settings';
-import QueryHistory from './pages/QueryHistory';
+const Connections = lazy(() => import('./pages/Connections'));
+const SqlLibrary = lazy(() => import('./pages/SqlLibrary'));
+const SingleTest = lazy(() => import('./pages/SingleTest'));
+const ParallelTest = lazy(() => import('./pages/ParallelTest'));
+const Reports = lazy(() => import('./pages/Reports'));
+const Analytics = lazy(() => import('./pages/Analytics'));
+const ComparisonTest = lazy(() => import('./pages/ComparisonTest'));
+const Settings = lazy(() => import('./pages/Settings'));
+const QueryHistory = lazy(() => import('./pages/QueryHistory'));
 import NotFound from './pages/NotFound';
 
 type NavItem =
@@ -117,6 +118,7 @@ export default function App() {
         <div className="main-area">
           <TopBar wsConnected={wsConnected} />
           <main id="main-content" className="page-content fade-in" role="main">
+            <Suspense fallback={<PageLoader />}>
             <Routes>
               <Route path="/" element={<SingleTest wsMessages={wsMessages} subscribeTestId={subscribeTestId} />} />
               <Route path="/connections" element={<Connections />} />
@@ -130,6 +132,7 @@ export default function App() {
               <Route path="/settings" element={<Settings />} />
               <Route path="*" element={<NotFound />} />
             </Routes>
+            </Suspense>
           </main>
         </div>
       </div>

--- a/web-ui/src/components/PageLoader.tsx
+++ b/web-ui/src/components/PageLoader.tsx
@@ -1,0 +1,11 @@
+import { useTranslation } from 'react-i18next';
+
+export default function PageLoader() {
+  const { t } = useTranslation();
+  return (
+    <div className="page-loader">
+      <div className="page-loader-spinner" />
+      <p>{t('app.loading', 'Loading...')}</p>
+    </div>
+  );
+}

--- a/web-ui/src/index.css
+++ b/web-ui/src/index.css
@@ -490,6 +490,26 @@ tbody td { padding: var(--space-3) var(--space-4); vertical-align: middle; }
 @keyframes fadeIn { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
 .fade-in { animation: fadeIn 200ms ease; }
 
+/* ─── Page loader (Suspense fallback) ────────────────────── */
+.page-loader {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--gap);
+  min-height: 200px;
+  color: var(--color-muted);
+}
+.page-loader-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
 /* ─── Recharts theme overrides ───────────────────────────── */
 .recharts-tooltip-wrapper .recharts-default-tooltip {
   background: var(--color-surface-2) !important;

--- a/web-ui/vite.config.ts
+++ b/web-ui/vite.config.ts
@@ -9,6 +9,17 @@ export default defineConfig({
       '@shared/types': path.resolve(__dirname, '../lib/types/index.ts'),
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ['react', 'react-dom', 'react-router-dom'],
+          recharts: ['recharts'],
+          i18n: ['i18next', 'react-i18next', 'i18next-browser-languagedetector'],
+        },
+      },
+    },
+  },
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
## Summary
- Convert all page imports to `React.lazy()` with `Suspense`
- Add `PageLoader` spinner component as fallback
- Configure `manualChunks` in vite.config.ts (vendor, recharts, i18n)

## Bundle Size Comparison

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Initial JS | 773.44 KB | 209.31 KB | **-73%** |
| Initial gzip | 229.62 KB | 66.78 KB | **-71%** |

### After (chunked)
- `index.js`: 209 KB (app shell + shared code)
- `recharts.js`: 381 KB (lazy, chart pages only)
- `vendor.js`: 40 KB (react/react-dom/react-router)
- `i18n.js`: 63 KB (i18next)
- Page chunks: 1-13 KB each (lazy loaded on navigation)

## Test plan
- [x] `npm run build` succeeds with separate chunks
- [x] `npm run lint` passes
- [ ] Pages without charts (Connections, SqlLibrary, Settings) don't load recharts chunk
- [ ] Navigation between pages works correctly with lazy loading

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)