### PR TITLE
feat: add responsive mobile layout with hamburger menu (#94)

### DIFF
--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes, Route, NavLink, useLocation } from 'react-router-dom';
-import { lazy, Suspense, useState, useCallback } from 'react';
+import { lazy, Suspense, useState, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useWebSocket } from './hooks/useWebSocket';
 import type { WsMessage } from './types';
@@ -48,10 +48,10 @@ const PAGE_META_KEYS: Record<string, string> = {
   '/settings': 'settings',
 };
 
-function Sidebar() {
+function Sidebar({ open, onClose }: { open: boolean; onClose: () => void }) {
   const { t } = useTranslation();
   return (
-    <aside className="sidebar">
+    <aside className={`sidebar${open ? ' sidebar--open' : ''}`}>
       <div className="sidebar-logo">
         <h1>⚡ {t('app.logo')}</h1>
         <p>{t('app.logoSub')}</p>
@@ -66,6 +66,7 @@ function Sidebar() {
               to={item.path!}
               className={({ isActive }) => `nav-item${isActive ? ' active' : ''}`}
               aria-current={undefined}
+              onClick={onClose}
             >
               <span className="nav-icon" aria-hidden="true">{item.icon}</span>
               {t(item.labelKey!)}
@@ -77,7 +78,11 @@ function Sidebar() {
   );
 }
 
-function TopBar({ wsConnected }: { wsConnected: boolean }) {
+function TopBar({ wsConnected, onMenuToggle, menuOpen }: {
+  wsConnected: boolean;
+  onMenuToggle: () => void;
+  menuOpen: boolean;
+}) {
   const { t } = useTranslation();
   const location = useLocation();
   const metaKey = PAGE_META_KEYS[location.pathname];
@@ -85,6 +90,14 @@ function TopBar({ wsConnected }: { wsConnected: boolean }) {
   const subtitle = metaKey ? t(`pageMeta.${metaKey}.subtitle`) : undefined;
   return (
     <header className="topbar">
+      <button
+        className="hamburger-btn"
+        onClick={onMenuToggle}
+        aria-label={t('app.menuToggle')}
+        aria-expanded={menuOpen}
+      >
+        <span className="hamburger-icon" />
+      </button>
       <div>
         <div className="topbar-title">{title}</div>
         {subtitle && <div className="topbar-subtitle">{subtitle}</div>}
@@ -97,9 +110,21 @@ function TopBar({ wsConnected }: { wsConnected: boolean }) {
   );
 }
 
+function RouteChangeHandler({ onRouteChange }: { onRouteChange: () => void }) {
+  const location = useLocation();
+  useEffect(() => {
+    onRouteChange();
+  }, [location.pathname, onRouteChange]);
+  return null;
+}
+
 export default function App() {
   const [wsConnected, setWsConnected] = useState(false);
   const [wsMessages, setWsMessages] = useState<WsMessage[]>([]);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const closeSidebar = useCallback(() => setSidebarOpen(false), []);
+  const toggleSidebar = useCallback(() => setSidebarOpen(prev => !prev), []);
 
   const handleWsMessage = useCallback((msg: WsMessage) => {
     if (msg.type === 'connected') {
@@ -112,11 +137,15 @@ export default function App() {
 
   return (
     <BrowserRouter>
+      <RouteChangeHandler onRouteChange={closeSidebar} />
       <div className="layout">
         <a href="#main-content" className="skip-to-content">Skip to content</a>
-        <Sidebar />
+        {sidebarOpen && (
+          <div className="sidebar-overlay" onClick={closeSidebar} role="presentation" />
+        )}
+        <Sidebar open={sidebarOpen} onClose={closeSidebar} />
         <div className="main-area">
-          <TopBar wsConnected={wsConnected} />
+          <TopBar wsConnected={wsConnected} onMenuToggle={toggleSidebar} menuOpen={sidebarOpen} />
           <main id="main-content" className="page-content fade-in" role="main">
             <Suspense fallback={<PageLoader />}>
             <Routes>

--- a/web-ui/src/i18n/locales/en.json
+++ b/web-ui/src/i18n/locales/en.json
@@ -19,7 +19,8 @@
     "logoSub": "Performance Tester",
     "wsConnected": "WS Connected",
     "wsDisconnected": "WS Disconnected",
-    "defaultTitle": "MySQL Performance Tester"
+    "defaultTitle": "MySQL Performance Tester",
+    "menuToggle": "Toggle navigation menu"
   },
   "pageMeta": {
     "connections": { "title": "Connections", "subtitle": "Register and test MySQL connections" },

--- a/web-ui/src/i18n/locales/ja.json
+++ b/web-ui/src/i18n/locales/ja.json
@@ -19,7 +19,8 @@
     "logoSub": "Performance Tester",
     "wsConnected": "WS Connected",
     "wsDisconnected": "WS Disconnected",
-    "defaultTitle": "MySQL Performance Tester"
+    "defaultTitle": "MySQL Performance Tester",
+    "menuToggle": "ナビゲーションメニューの切替"
   },
   "pageMeta": {
     "connections": { "title": "接続管理", "subtitle": "MySQL 接続先の登録と疎通確認" },

--- a/web-ui/src/index.css
+++ b/web-ui/src/index.css
@@ -174,6 +174,46 @@ body {
 .ws-badge.connected { background: rgba(63,185,80,.15); color: var(--color-success); }
 .ws-badge.disconnected { background: rgba(248,81,73,.15); color: var(--color-danger); }
 
+/* ─── Hamburger button (hidden on desktop) ───────────────── */
+.hamburger-btn {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  border-radius: var(--radius);
+  flex-shrink: 0;
+}
+.hamburger-btn:hover { background: var(--color-surface-2); }
+.hamburger-icon {
+  display: block;
+  width: 18px;
+  height: 2px;
+  background: var(--color-text);
+  position: relative;
+}
+.hamburger-icon::before,
+.hamburger-icon::after {
+  content: '';
+  display: block;
+  width: 18px;
+  height: 2px;
+  background: var(--color-text);
+  position: absolute;
+  left: 0;
+}
+.hamburger-icon::before { top: -6px; }
+.hamburger-icon::after  { top:  6px; }
+
+/* ─── Sidebar overlay (mobile only) ─────────────────────── */
+.sidebar-overlay {
+  display: none;
+}
+
 .page-content {
   flex: 1;
   overflow-y: auto;
@@ -545,4 +585,47 @@ tbody td { padding: var(--space-3) var(--space-4); vertical-align: middle; }
 }
 :focus:not(:focus-visible) {
   outline: none;
+}
+
+/* ============================================================
+   Mobile Responsive Layout (< 768px)
+   ============================================================ */
+@media (max-width: 768px) {
+  .sidebar {
+    position: fixed;
+    top: 0;
+    left: calc(-1 * var(--sidebar-w));
+    height: 100vh;
+    z-index: 100;
+    transition: left 0.3s ease;
+  }
+  .sidebar.sidebar--open {
+    left: 0;
+  }
+
+  .sidebar-overlay {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 99;
+  }
+
+  .hamburger-btn {
+    display: flex;
+  }
+
+  .main-area {
+    margin-left: 0;
+    width: 100%;
+  }
+
+  .page-content {
+    padding: var(--space-4);
+  }
+
+  .topbar {
+    padding: 0 var(--space-4);
+    gap: var(--space-3);
+  }
 }


### PR DESCRIPTION
## Summary
- Add hamburger toggle button in TopBar (visible only below 768px breakpoint)
- Implement slide-out sidebar with CSS transition + overlay backdrop
- Close sidebar on navigation, overlay click, and route change
- Add i18n keys for aria-label (en/ja)

## Changes
- **`App.tsx`**: Add `sidebarOpen` state, `RouteChangeHandler`, hamburger button in TopBar
- **`index.css`**: Hamburger button styles, sidebar overlay, `@media (max-width: 768px)` responsive rules
- **`en.json`/`ja.json`**: Add `app.menuToggle` key

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [ ] Desktop (1280px): layout unchanged, no hamburger visible
- [ ] Mobile (375px): hamburger visible, sidebar slides out, overlay appears
- [ ] NavLink click closes sidebar on mobile
- [ ] Both en/ja labels render

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)