### PR TITLE
feat: add Zod runtime validation for API responses (#95)

### DIFF
--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -14,7 +14,8 @@
         "react-dom": "^19.2.0",
         "react-i18next": "^17.0.2",
         "react-router-dom": "^7.13.1",
-        "recharts": "^3.8.0"
+        "recharts": "^3.8.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -6468,7 +6469,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -20,7 +20,8 @@
     "react-dom": "^19.2.0",
     "react-i18next": "^17.0.2",
     "react-router-dom": "^7.13.1",
-    "recharts": "^3.8.0"
+    "recharts": "^3.8.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/web-ui/src/api/__tests__/schemas.test.ts
+++ b/web-ui/src/api/__tests__/schemas.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ConnectionSchema,
+  ConnectionListSchema,
+  ConnectionTestResultSchema,
+  SqlItemSchema,
+  SqlItemListSchema,
+  CategoriesSchema,
+  TestIdSchema,
+  ReportSummarySchema,
+  ReportSummaryListSchema,
+  QueryFingerprintSummarySchema,
+  QueryEventSchema,
+  QueryTimelineSchema,
+} from '../schemas/index.js';
+
+describe('API Response Schemas', () => {
+  describe('ConnectionSchema', () => {
+    it('validates a valid connection', () => {
+      const result = ConnectionSchema.safeParse({
+        id: 'conn_abc123',
+        name: 'Test DB',
+        host: 'localhost',
+        port: 3306,
+        database: 'testdb',
+        user: 'root',
+        passwordMasked: '••••••••',
+        poolSize: 10,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts extra fields (passthrough)', () => {
+      const result = ConnectionSchema.safeParse({
+        id: 'conn_abc123',
+        name: 'Test DB',
+        host: 'localhost',
+        port: 3306,
+        database: 'testdb',
+        user: 'root',
+        passwordMasked: '••••••••',
+        poolSize: 10,
+        extraField: 'ignored',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects missing required fields', () => {
+      const result = ConnectionSchema.safeParse({
+        id: 'conn_abc123',
+        name: 'Test DB',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects wrong types', () => {
+      const result = ConnectionSchema.safeParse({
+        id: 'conn_abc123',
+        name: 'Test DB',
+        host: 'localhost',
+        port: 'not-a-number',
+        database: 'testdb',
+        user: 'root',
+        passwordMasked: '••••••••',
+        poolSize: 10,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('ConnectionListSchema', () => {
+    it('validates an empty array', () => {
+      expect(ConnectionListSchema.safeParse([]).success).toBe(true);
+    });
+
+    it('validates an array of connections', () => {
+      const result = ConnectionListSchema.safeParse([
+        { id: 'conn_1', name: 'A', host: 'h', port: 3306, database: 'd', user: 'u', passwordMasked: '', poolSize: 5 },
+      ]);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('ConnectionTestResultSchema', () => {
+    it('validates a test result', () => {
+      const result = ConnectionTestResultSchema.safeParse({
+        connected: true,
+        serverVersion: '8.0.36',
+        supportsExplainAnalyze: true,
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('SqlItemSchema', () => {
+    it('validates a valid SQL item', () => {
+      const result = SqlItemSchema.safeParse({
+        id: 'sql_abc',
+        name: 'Test Query',
+        sql: 'SELECT 1',
+        category: 'test',
+        description: 'A test query',
+        updatedAt: '2026-01-01T00:00:00Z',
+        createdAt: '2026-01-01T00:00:00Z',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts optional tags', () => {
+      const result = SqlItemSchema.safeParse({
+        id: 'sql_abc',
+        name: 'Test',
+        sql: 'SELECT 1',
+        category: 'test',
+        description: '',
+        tags: '["perf"]',
+        updatedAt: '2026-01-01T00:00:00Z',
+        createdAt: '2026-01-01T00:00:00Z',
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('SqlItemListSchema', () => {
+    it('validates an empty array', () => {
+      expect(SqlItemListSchema.safeParse([]).success).toBe(true);
+    });
+  });
+
+  describe('CategoriesSchema', () => {
+    it('validates string array', () => {
+      expect(CategoriesSchema.safeParse(['perf', 'debug']).success).toBe(true);
+    });
+
+    it('rejects non-string items', () => {
+      expect(CategoriesSchema.safeParse([1, 2]).success).toBe(false);
+    });
+  });
+
+  describe('TestIdSchema', () => {
+    it('validates test execution response', () => {
+      const result = TestIdSchema.safeParse({ testId: 'test_abc-123' });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects missing testId', () => {
+      expect(TestIdSchema.safeParse({}).success).toBe(false);
+    });
+  });
+
+  describe('ReportSummarySchema', () => {
+    it('validates a report summary', () => {
+      const result = ReportSummarySchema.safeParse({
+        id: 'test_abc',
+        type: 'single',
+        createdAt: '2026-01-01T00:00:00Z',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts optional testName', () => {
+      const result = ReportSummarySchema.safeParse({
+        id: 'test_abc',
+        type: 'single',
+        testName: 'My Test',
+        createdAt: '2026-01-01T00:00:00Z',
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('ReportSummaryListSchema', () => {
+    it('validates empty array', () => {
+      expect(ReportSummaryListSchema.safeParse([]).success).toBe(true);
+    });
+  });
+
+  describe('QueryFingerprintSummarySchema', () => {
+    it('validates a fingerprint summary', () => {
+      const result = QueryFingerprintSummarySchema.safeParse({
+        queryFingerprint: 'abc123',
+        queryText: 'SELECT 1',
+        latestTestName: 'Test',
+        runCount: 5,
+        latestRunAt: '2026-01-01T00:00:00Z',
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('QueryEventSchema', () => {
+    it('validates a query event', () => {
+      const result = QueryEventSchema.safeParse({
+        id: 'evt_abc',
+        queryFingerprint: '0123456789abcdef',
+        label: 'Added index',
+        type: 'index_added',
+        timestamp: '2026-01-01T00:00:00Z',
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('QueryTimelineSchema', () => {
+    it('validates a timeline response', () => {
+      const result = QueryTimelineSchema.safeParse({
+        queryFingerprint: '0123456789abcdef',
+        queryText: 'SELECT 1',
+        entries: [
+          {
+            testId: 'test_1',
+            testName: 'Test',
+            timestamp: '2026-01-01T00:00:00Z',
+            statistics: { basic: { mean: 1.5 } },
+          },
+        ],
+        events: [],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('validates empty entries and events', () => {
+      const result = QueryTimelineSchema.safeParse({
+        queryFingerprint: '0123456789abcdef',
+        queryText: '',
+        entries: [],
+        events: [],
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -3,6 +3,7 @@
  * All API calls go through this module
  */
 
+import type { ZodType } from 'zod';
 import type {
   Connection,
   ConnectionFormData,
@@ -18,6 +19,19 @@ import type {
   QueryEvent,
   CreateEventInput,
 } from '../types';
+import {
+  ConnectionListSchema,
+  ConnectionSchema,
+  ConnectionTestResultSchema,
+  SqlItemListSchema,
+  SqlItemSchema,
+  CategoriesSchema,
+  TestIdSchema,
+  ReportSummaryListSchema,
+  QueryFingerprintListSchema,
+  QueryTimelineSchema,
+  QueryEventSchema,
+} from './schemas/index.js';
 
 interface ApiResponse<T> {
   success: boolean;
@@ -27,7 +41,7 @@ interface ApiResponse<T> {
 
 const BASE_URL = '/api';
 
-async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
+async function request<T>(method: string, path: string, body?: unknown, schema?: ZodType<T>): Promise<T> {
   const opts: RequestInit = {
     method,
     headers: { 'Content-Type': 'application/json' },
@@ -47,21 +61,35 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
   if (!res.ok || !data.success) {
     throw new Error(data.error || `HTTP ${res.status}`);
   }
+
+  if (schema) {
+    const parsed = schema.safeParse(data.data);
+    if (!parsed.success) {
+      console.warn(`[API] Response validation failed for ${method} ${path}:`, parsed.error.issues);
+    }
+  }
+
   return data.data;
 }
 
-const get = <T>(path: string): Promise<T> => request<T>('GET', path);
-const post = <T>(path: string, body?: unknown): Promise<T> => request<T>('POST', path, body);
-const put = <T>(path: string, body?: unknown): Promise<T> => request<T>('PUT', path, body);
+function get<T>(path: string, schema?: ZodType<T>): Promise<T> {
+  return request<T>('GET', path, undefined, schema);
+}
+function post<T>(path: string, body?: unknown, schema?: ZodType<T>): Promise<T> {
+  return request<T>('POST', path, body, schema);
+}
+function put<T>(path: string, body?: unknown, schema?: ZodType<T>): Promise<T> {
+  return request<T>('PUT', path, body, schema);
+}
 const del = <T>(path: string): Promise<T> => request<T>('DELETE', path);
 
 // ─── Connections ───────────────────────────────────────────────────────────
 export const connectionsApi = {
-  list: (): Promise<Connection[]> => get<Connection[]>('/connections'),
-  create: (data: ConnectionFormData): Promise<Connection> => post<Connection>('/connections', data),
-  update: (id: string, data: ConnectionFormData): Promise<Connection> => put<Connection>(`/connections/${id}`, data),
+  list: (): Promise<Connection[]> => get('/connections', ConnectionListSchema),
+  create: (data: ConnectionFormData): Promise<Connection> => post('/connections', data, ConnectionSchema),
+  update: (id: string, data: ConnectionFormData): Promise<Connection> => put(`/connections/${id}`, data, ConnectionSchema),
   remove: (id: string): Promise<void> => del<void>(`/connections/${id}`),
-  test: (id: string): Promise<ConnectionTestResult> => post<ConnectionTestResult>(`/connections/${id}/test`),
+  test: (id: string): Promise<ConnectionTestResult> => post('/connections/' + id + '/test', undefined, ConnectionTestResultSchema),
 };
 
 // ─── SQL Library ───────────────────────────────────────────────────────────
@@ -71,27 +99,27 @@ export const sqlApi = {
       Object.entries(filters).filter(([, v]) => v !== undefined && v !== null && v !== '')
     );
     const params = new URLSearchParams(cleaned as Record<string, string>).toString();
-    return get<SqlItem[]>(`/sql${params ? '?' + params : ''}`);
+    return get(`/sql${params ? '?' + params : ''}`, SqlItemListSchema);
   },
-  get: (id: string): Promise<SqlItem> => get<SqlItem>(`/sql/${id}`),
-  categories: (): Promise<string[]> => get<string[]>('/sql/categories'),
-  create: (data: SqlFormData): Promise<SqlItem> => post<SqlItem>('/sql', data),
-  update: (id: string, data: SqlFormData): Promise<SqlItem> => put<SqlItem>(`/sql/${id}`, data),
+  get: (id: string): Promise<SqlItem> => get(`/sql/${id}`, SqlItemSchema),
+  categories: (): Promise<string[]> => get('/sql/categories', CategoriesSchema),
+  create: (data: SqlFormData): Promise<SqlItem> => post('/sql', data, SqlItemSchema),
+  update: (id: string, data: SqlFormData): Promise<SqlItem> => put(`/sql/${id}`, data, SqlItemSchema),
   remove: (id: string): Promise<void> => del<void>(`/sql/${id}`),
 };
 
 // ─── Tests ─────────────────────────────────────────────────────────────────
 export const testsApi = {
-  runSingle: (data: unknown): Promise<{ testId: string }> => post<{ testId: string }>('/tests/single', data),
-  runParallel: (data: unknown): Promise<{ testId: string }> => post<{ testId: string }>('/tests/parallel', data),
-  runComparison: (data: unknown): Promise<{ testId: string }> => post<{ testId: string }>('/tests/comparison', data),
+  runSingle: (data: unknown): Promise<{ testId: string }> => post('/tests/single', data, TestIdSchema),
+  runParallel: (data: unknown): Promise<{ testId: string }> => post('/tests/parallel', data, TestIdSchema),
+  runComparison: (data: unknown): Promise<{ testId: string }> => post('/tests/comparison', data, TestIdSchema),
   listResults: (): Promise<unknown[]> => get<unknown[]>('/tests/results'),
   getResult: (id: string): Promise<unknown> => get<unknown>(`/tests/results/${id}`),
 };
 
 // ─── Reports ───────────────────────────────────────────────────────────────
 export const reportsApi = {
-  list: (): Promise<ReportSummary[]> => get<ReportSummary[]>('/reports'),
+  list: (): Promise<ReportSummary[]> => get('/reports', ReportSummaryListSchema),
   get: (id: string): Promise<ReportDetail> => get<ReportDetail>(`/reports/${id}`),
   exportUrl: (id: string, format: string): string =>
     `${BASE_URL}/reports/${encodeURIComponent(id)}/export?format=${encodeURIComponent(format)}`,
@@ -100,15 +128,15 @@ export const reportsApi = {
 // ─── History ──────────────────────────────────────────────────────────────
 export const historyApi = {
   fingerprints: (): Promise<QueryFingerprintSummary[]> =>
-    get<QueryFingerprintSummary[]>('/history/fingerprints'),
+    get('/history/fingerprints', QueryFingerprintListSchema),
   timeline: (fp: string): Promise<QueryTimeline> =>
-    get<QueryTimeline>(`/history/${encodeURIComponent(fp)}`),
+    get(`/history/${encodeURIComponent(fp)}`, QueryTimelineSchema),
   compare: (fp: string, before: string, after: string): Promise<HistoryComparison> =>
     get<HistoryComparison>(
       `/history/${encodeURIComponent(fp)}/compare?before=${encodeURIComponent(before)}&after=${encodeURIComponent(after)}`
     ),
   createEvent: (data: CreateEventInput): Promise<QueryEvent> =>
-    post<QueryEvent>('/history/events', data),
+    post('/history/events', data, QueryEventSchema),
   deleteEvent: (id: string): Promise<void> =>
     del<void>(`/history/events/${id}`),
 };

--- a/web-ui/src/api/schemas/connections.ts
+++ b/web-ui/src/api/schemas/connections.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const ConnectionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  host: z.string(),
+  port: z.number(),
+  database: z.string(),
+  user: z.string(),
+  passwordMasked: z.string(),
+  poolSize: z.number(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+}).passthrough();
+
+export const ConnectionTestResultSchema = z.object({
+  connected: z.boolean().optional(),
+  serverVersion: z.string().optional(),
+  supportsExplainAnalyze: z.boolean().optional(),
+}).passthrough();
+
+export const ConnectionListSchema = z.array(ConnectionSchema);

--- a/web-ui/src/api/schemas/history.ts
+++ b/web-ui/src/api/schemas/history.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+export const QueryFingerprintSummarySchema = z.object({
+  queryFingerprint: z.string(),
+  queryText: z.string(),
+  latestTestName: z.string(),
+  runCount: z.number(),
+  latestRunAt: z.string(),
+}).passthrough();
+
+export const QueryFingerprintListSchema = z.array(QueryFingerprintSummarySchema);
+
+export const QueryEventSchema = z.object({
+  id: z.string(),
+  queryFingerprint: z.string(),
+  label: z.string(),
+  type: z.string(),
+  timestamp: z.string(),
+}).passthrough();
+
+export const QueryTimelineSchema = z.object({
+  queryFingerprint: z.string(),
+  queryText: z.string(),
+  entries: z.array(z.object({
+    testId: z.string(),
+    testName: z.string(),
+    timestamp: z.string(),
+    statistics: z.record(z.string(), z.unknown()),
+    explainAccessType: z.string().optional(),
+  }).passthrough()),
+  events: z.array(QueryEventSchema),
+}).passthrough();

--- a/web-ui/src/api/schemas/index.ts
+++ b/web-ui/src/api/schemas/index.ts
@@ -1,0 +1,10 @@
+export { ConnectionSchema, ConnectionListSchema, ConnectionTestResultSchema } from './connections.js';
+export { SqlItemSchema, SqlItemListSchema, CategoriesSchema } from './sql-library.js';
+export { TestIdSchema } from './tests.js';
+export { ReportSummarySchema, ReportSummaryListSchema } from './reports.js';
+export {
+  QueryFingerprintSummarySchema,
+  QueryFingerprintListSchema,
+  QueryEventSchema,
+  QueryTimelineSchema,
+} from './history.js';

--- a/web-ui/src/api/schemas/reports.ts
+++ b/web-ui/src/api/schemas/reports.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const ReportSummarySchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  testName: z.string().optional(),
+  createdAt: z.string(),
+}).passthrough();
+
+export const ReportSummaryListSchema = z.array(ReportSummarySchema);

--- a/web-ui/src/api/schemas/sql-library.ts
+++ b/web-ui/src/api/schemas/sql-library.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const SqlItemSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  sql: z.string(),
+  category: z.string(),
+  description: z.string(),
+  tags: z.string().optional(),
+  updatedAt: z.string(),
+  createdAt: z.string(),
+}).passthrough();
+
+export const SqlItemListSchema = z.array(SqlItemSchema);
+
+export const CategoriesSchema = z.array(z.string());

--- a/web-ui/src/api/schemas/tests.ts
+++ b/web-ui/src/api/schemas/tests.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const TestIdSchema = z.object({
+  testId: z.string(),
+}).passthrough();


### PR DESCRIPTION
## Summary
- Add Zod schemas for all API response types in `web-ui/src/api/schemas/`
- Integrate validation into centralized `request<T>()` function
- Graceful degradation: `console.warn` on validation failure (no throw)
- 21 unit tests for schema validation

## Changes
- **`web-ui/src/api/schemas/`** (6 new files): Zod schemas for connections, sql-library, tests, reports, history
- **`web-ui/src/api/client.ts`**: Add optional `schema` param to `request()`, `get()`, `post()`, `put()`
- **`web-ui/src/api/__tests__/schemas.test.ts`**: 21 tests covering valid/invalid/passthrough cases

## Design decisions
- **Graceful degradation**: `safeParse()` + `console.warn` instead of throwing, to avoid breaking the UI
- **`.passthrough()`**: Allows extra fields for forward compatibility
- **Schema per namespace**: Mirrors the API client structure for maintainability

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] 21 schema tests pass
- [ ] API calls work normally with no console warnings

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)